### PR TITLE
topsql: fix pd_address optional

### DIFF
--- a/src/sources/keyviz.rs
+++ b/src/sources/keyviz.rs
@@ -80,7 +80,7 @@ impl SourceConfig for KeyvizConfig {
 
             // Since we already checked is_nextgen_mode() above, we know we're in legacy mode here
             let topo = TopologyFetcher::new(
-                pd_address.clone(),
+                Some(pd_address.clone()),
                 tls.clone(),
                 &cx.proxy,
                 None, // tidb_group

--- a/src/sources/topsql/controller.rs
+++ b/src/sources/topsql/controller.rs
@@ -39,7 +39,7 @@ struct ActiveSchemaManager {
 
 impl Controller {
     pub async fn new(
-        pd_address: String,
+        pd_address: Option<String>,
         topo_fetch_interval: Duration,
         init_retry_delay: Duration,
         top_n: usize,

--- a/src/sources/topsql/mod.rs
+++ b/src/sources/topsql/mod.rs
@@ -24,7 +24,7 @@ pub mod upstream;
 #[derive(Debug, Clone)]
 pub struct TopSQLConfig {
     /// PD address for legacy mode
-    pub pd_address: String,
+    pub pd_address: Option<String>,
 
     /// TLS configuration
     pub tls: Option<TlsConfig>,
@@ -75,7 +75,7 @@ pub const fn default_downsampling_interval() -> u32 {
 impl GenerateConfig for TopSQLConfig {
     fn generate_config() -> toml::Value {
         toml::Value::try_from(Self {
-            pd_address: "127.0.0.1:2379".to_owned(),
+            pd_address: Some("127.0.0.1:2379".to_owned()),
             tls: None,
             init_retry_delay_seconds: default_init_retry_delay(),
             topology_fetch_interval_seconds: default_topology_fetch_interval(),

--- a/src/sources/topsql/topology/fetch/mod.rs
+++ b/src/sources/topsql/topology/fetch/mod.rs
@@ -49,6 +49,8 @@ pub enum FetchError {
     FetchTiDBNextGenTopology { source: tidb_nextgen::FetchError },
     #[snafu(display("Failed to fetch tikv nextgen topology: {}", source))]
     FetchTiKVNextGenTopology { source: tikv_nextgen::FetchError },
+    #[snafu(display("Configuration error: {}", message))]
+    ConfigurationError { message: String },
 }
 
 // Legacy topology fetcher
@@ -230,7 +232,7 @@ enum TopologyFetcherImpl {
 impl TopologyFetcher {
     /// Create a new topology fetcher based on the current feature configuration
     pub async fn new(
-        pd_address: String,
+        pd_address: Option<String>,
         tls_config: Option<TlsConfig>,
         proxy_config: &ProxyConfig,
         tidb_group: Option<String>,
@@ -245,6 +247,10 @@ impl TopologyFetcher {
                 inner: TopologyFetcherImpl::Nextgen(fetcher),
             })
         } else {
+            // In legacy mode, pd_address is required
+            let pd_address = pd_address.ok_or_else(|| FetchError::ConfigurationError { 
+                message: "PD address is required in legacy mode".to_string()
+            })?;
             let fetcher = LegacyTopologyFetcher::new(pd_address, tls_config, proxy_config).await?;
             Ok(Self {
                 inner: TopologyFetcherImpl::Legacy(fetcher),


### PR DESCRIPTION
Fix the issue error `missing pd_address` report with NextGen Deploy.

