### PR TITLE
Add meta-store routing for topsql deltalake sink

### DIFF
--- a/src/common/meta_store.rs
+++ b/src/common/meta_store.rs
@@ -1,0 +1,186 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KeyspaceRoute {
+    pub org_id: String,
+    pub cluster_id: String,
+}
+
+#[derive(Clone)]
+pub struct MetaStoreResolver {
+    base_url: String,
+    client: Client,
+    cache: Arc<Mutex<HashMap<String, KeyspaceRoute>>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetaStoreKeyspaceMetadata {
+    #[serde(rename = "ClusterId", alias = "cluster_id")]
+    cluster_id: String,
+    #[serde(rename = "TenantID", alias = "tenant_id")]
+    tenant_id: String,
+}
+
+impl MetaStoreResolver {
+    pub fn new(meta_store_addr: impl Into<String>) -> Result<Self, BoxError> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .connect_timeout(Duration::from_secs(3))
+            .build()?;
+        Ok(Self::new_with_client(meta_store_addr, client))
+    }
+
+    pub fn new_with_client(meta_store_addr: impl Into<String>, client: Client) -> Self {
+        Self {
+            base_url: normalize_meta_store_addr(&meta_store_addr.into()),
+            client,
+            cache: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn resolve_keyspace(
+        &self,
+        keyspace_name: &str,
+    ) -> Result<Option<KeyspaceRoute>, BoxError> {
+        if keyspace_name.is_empty() {
+            return Ok(None);
+        }
+
+        if let Some(cached) = self.cache.lock().await.get(keyspace_name).cloned() {
+            return Ok(Some(cached));
+        }
+
+        let response = self
+            .client
+            .get(format!("{}/api/v2/meta", self.base_url))
+            .query(&[("keyspace_name", keyspace_name)])
+            .send()
+            .await?;
+
+        match response.status() {
+            StatusCode::NOT_FOUND => return Ok(None),
+            status if !status.is_success() => {
+                return Err(format!(
+                    "meta-store lookup failed for keyspace {} with status {}",
+                    keyspace_name, status
+                )
+                .into());
+            }
+            _ => {}
+        }
+
+        let metadata: Vec<MetaStoreKeyspaceMetadata> = response.json().await?;
+        let Some(first) = metadata.into_iter().next() else {
+            return Ok(None);
+        };
+
+        if first.cluster_id.is_empty() || first.tenant_id.is_empty() {
+            return Ok(None);
+        }
+
+        let route = KeyspaceRoute {
+            org_id: first.tenant_id,
+            cluster_id: first.cluster_id,
+        };
+        self.cache
+            .lock()
+            .await
+            .insert(keyspace_name.to_string(), route.clone());
+
+        Ok(Some(route))
+    }
+}
+
+fn normalize_meta_store_addr(meta_store_addr: &str) -> String {
+    let trimmed = meta_store_addr.trim().trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
+    } else {
+        format!("http://{}", trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use hyper::service::{make_service_fn, service_fn};
+    use hyper::{Body, Request, Response, Server};
+
+    use super::*;
+
+    #[test]
+    fn normalize_meta_store_addr_adds_scheme() {
+        assert_eq!(
+            normalize_meta_store_addr("meta-store:9088/"),
+            "http://meta-store:9088"
+        );
+        assert_eq!(
+            normalize_meta_store_addr("https://meta-store:9088"),
+            "https://meta-store:9088"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_keyspace_uses_tenant_as_org_id_and_caches_result() {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&request_count);
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = Server::from_tcp(listener)
+            .unwrap()
+            .serve(make_service_fn(move |_| {
+                let counter = Arc::clone(&counter);
+                async move {
+                    Ok::<_, Infallible>(service_fn(move |request: Request<Body>| {
+                        let counter = Arc::clone(&counter);
+                        async move {
+                            counter.fetch_add(1, Ordering::SeqCst);
+                            assert_eq!(request.uri().path(), "/api/v2/meta");
+                            assert!(
+                                request
+                                    .uri()
+                                    .query()
+                                    .unwrap_or_default()
+                                    .contains("keyspace_name=test_keyspace"),
+                                "query should contain keyspace_name=test_keyspace"
+                            );
+                            Ok::<_, Infallible>(Response::new(Body::from(
+                                r#"[{"ClusterId":"10110362358366286743","TenantID":"1369847559692509642"}]"#,
+                            )))
+                        }
+                    }))
+                }
+            }));
+        let server_handle = tokio::spawn(server);
+
+        let resolver = MetaStoreResolver::new(format!("http://{}", address)).unwrap();
+
+        let first = resolver.resolve_keyspace("test_keyspace").await.unwrap();
+        let second = resolver.resolve_keyspace("test_keyspace").await.unwrap();
+
+        assert_eq!(
+            first,
+            Some(KeyspaceRoute {
+                org_id: "1369847559692509642".to_string(),
+                cluster_id: "10110362358366286743".to_string(),
+            })
+        );
+        assert_eq!(second, first);
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+
+        server_handle.abort();
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -2,4 +2,5 @@ pub mod checkpointer;
 pub mod deltalake_s3;
 pub mod deltalake_writer;
 pub mod features;
+pub mod meta_store;
 pub mod topology;

--- a/src/sinks/topsql_data_deltalake/mod.rs
+++ b/src/sinks/topsql_data_deltalake/mod.rs
@@ -25,8 +25,9 @@ use tracing::{error, info, warn};
 mod processor;
 
 // Import default functions from common module
-use crate::common::deltalake_writer::{default_batch_size, default_timeout_secs};
 use crate::common::deltalake_s3;
+use crate::common::deltalake_writer::{default_batch_size, default_timeout_secs};
+use crate::common::meta_store::MetaStoreResolver;
 
 pub const fn default_max_delay_secs() -> u64 {
     180
@@ -54,6 +55,9 @@ pub struct DeltaLakeConfig {
     /// Maximum delay in seconds before forcing a batch flush
     #[serde(default = "default_max_delay_secs")]
     pub max_delay_secs: u64,
+
+    /// Meta-store address used to resolve keyspace to org/cluster path segments
+    pub meta_store_addr: Option<String>,
 
     /// Storage options for cloud storage
     pub storage_options: Option<HashMap<String, String>>,
@@ -100,6 +104,7 @@ impl GenerateConfig for DeltaLakeConfig {
             batch_size: default_batch_size(),
             timeout_secs: default_timeout_secs(),
             max_delay_secs: default_max_delay_secs(),
+            meta_store_addr: None,
             storage_options: None,
             bucket: None,
             options: None,
@@ -219,12 +224,25 @@ impl DeltaLakeConfig {
             info!("No S3 service available - using default storage options only");
         }
 
+        let meta_store_resolver = self
+            .meta_store_addr
+            .as_deref()
+            .map(MetaStoreResolver::new)
+            .transpose()
+            .map_err(|error| {
+                vector::Error::from(format!(
+                    "failed to build meta-store resolver from meta_store_addr: {}",
+                    error
+                ))
+            })?;
+
         let sink = TopSQLDeltaLakeSink::new(
             base_path,
             table_configs,
             write_config,
             self.max_delay_secs,
             Some(storage_options),
+            meta_store_resolver,
         );
 
         Ok(VectorSink::from_event_streamsink(sink))

--- a/src/sinks/topsql_data_deltalake/processor.rs
+++ b/src/sinks/topsql_data_deltalake/processor.rs
@@ -3,21 +3,21 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use futures::{stream::BoxStream, StreamExt};
-use tokio::sync::Mutex;
 use tokio::sync::mpsc;
-use vector_lib::event::Event;
+use tokio::sync::Mutex;
+use vector_lib::event::{Event, LogEvent};
 use vector_lib::sink::StreamSink;
 
 use crate::common::deltalake_writer::{DeltaLakeWriter, DeltaTableConfig, WriteConfig};
+use crate::common::meta_store::{KeyspaceRoute, MetaStoreResolver};
 use crate::sources::topsql_v2::upstream::consts::{
-    LABEL_PLAN_DIGEST, LABEL_REGION_ID, LABEL_INSTANCE_KEY, LABEL_SQL_DIGEST, LABEL_TIMESTAMPS,
-    LABEL_DATE, LABEL_KEYSPACE, LABEL_TAG_LABEL, LABEL_DB_NAME, LABEL_TABLE_NAME, LABEL_TABLE_ID,
-    LABEL_SOURCE_TABLE, LABEL_USER, SOURCE_TABLE_TOPRU,
-    METRIC_NAME_CPU_TIME_MS, METRIC_NAME_LOGICAL_READ_BYTES, METRIC_NAME_LOGICAL_WRITE_BYTES,
+    LABEL_DATE, LABEL_DB_NAME, LABEL_INSTANCE_KEY, LABEL_KEYSPACE, LABEL_PLAN_DIGEST,
+    LABEL_REGION_ID, LABEL_SOURCE_TABLE, LABEL_SQL_DIGEST, LABEL_TABLE_ID, LABEL_TABLE_NAME,
+    LABEL_TAG_LABEL, LABEL_TIMESTAMPS, LABEL_USER, METRIC_NAME_CPU_TIME_MS, METRIC_NAME_EXEC_COUNT,
+    METRIC_NAME_EXEC_DURATION, METRIC_NAME_LOGICAL_READ_BYTES, METRIC_NAME_LOGICAL_WRITE_BYTES,
     METRIC_NAME_NETWORK_IN_BYTES, METRIC_NAME_NETWORK_OUT_BYTES, METRIC_NAME_READ_KEYS,
-    METRIC_NAME_STMT_EXEC_COUNT, METRIC_NAME_WRITE_KEYS,
-    METRIC_NAME_STMT_DURATION_COUNT, METRIC_NAME_STMT_DURATION_SUM_NS,
-    METRIC_NAME_TOTAL_RU, METRIC_NAME_EXEC_COUNT, METRIC_NAME_EXEC_DURATION,
+    METRIC_NAME_STMT_DURATION_COUNT, METRIC_NAME_STMT_DURATION_SUM_NS, METRIC_NAME_STMT_EXEC_COUNT,
+    METRIC_NAME_TOTAL_RU, METRIC_NAME_WRITE_KEYS, SOURCE_TABLE_TOPRU,
 };
 
 use lazy_static::lazy_static;
@@ -72,7 +72,7 @@ lazy_static! {
                 "mysql_type": "text",
                 "is_nullable": true
             }),
-        );        
+        );
         schema_info.insert(
             LABEL_SQL_DIGEST.into(),
             serde_json::json!({
@@ -254,8 +254,15 @@ pub struct TopSQLDeltaLakeSink {
     write_config: WriteConfig,
     max_delay_secs: u64,
     storage_options: Option<HashMap<String, String>>,
-    writers: Arc<Mutex<HashMap<String, DeltaLakeWriter>>>,
+    meta_store_resolver: Option<MetaStoreResolver>,
+    writers: Arc<Mutex<HashMap<WriterKey, DeltaLakeWriter>>>,
     tx: Arc<mpsc::Sender<Vec<Vec<Event>>>>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct WriterKey {
+    table_name: String,
+    table_path: PathBuf,
 }
 
 impl TopSQLDeltaLakeSink {
@@ -266,11 +273,12 @@ impl TopSQLDeltaLakeSink {
         write_config: WriteConfig,
         max_delay_secs: u64,
         storage_options: Option<HashMap<String, String>>,
+        meta_store_resolver: Option<MetaStoreResolver>,
     ) -> Self {
         // Create a channel with capacity 1
         let (tx, rx) = mpsc::channel(1);
         let tx = Arc::new(tx);
-        
+
         // Create sink instance
         let sink = Arc::new(Self {
             base_path,
@@ -278,16 +286,17 @@ impl TopSQLDeltaLakeSink {
             write_config,
             max_delay_secs,
             storage_options,
+            meta_store_resolver,
             writers: Arc::new(Mutex::new(HashMap::new())),
             tx: Arc::clone(&tx),
         });
-        
+
         // Spawn process_events_loop as a separate tokio task to avoid blocking
         let sink_clone = Arc::clone(&sink);
         tokio::spawn(async move {
             sink_clone.process_events_loop(rx).await;
         });
-        
+
         // Return the sink (Arc::try_unwrap will fail because tokio task holds a reference,
         // so we use unsafe to manually get the inner value without decrementing the reference count)
         // Safety: We know there's exactly one more reference (the tokio task),
@@ -306,6 +315,7 @@ impl TopSQLDeltaLakeSink {
                 write_config: inner_ref.write_config.clone(),
                 max_delay_secs: inner_ref.max_delay_secs,
                 storage_options: inner_ref.storage_options.clone(),
+                meta_store_resolver: inner_ref.meta_store_resolver.clone(),
                 writers: Arc::clone(&inner_ref.writers),
                 tx: Arc::clone(&inner_ref.tx),
             };
@@ -314,7 +324,7 @@ impl TopSQLDeltaLakeSink {
             inner_value
         }
     }
-    
+
     #[cfg(test)]
     /// Create a new Delta Lake sink for testing, returning both the sink and the receiver
     /// The receiver can be used to verify messages sent through the channel
@@ -325,11 +335,15 @@ impl TopSQLDeltaLakeSink {
         write_config: WriteConfig,
         max_delay_secs: u64,
         storage_options: Option<HashMap<String, String>>,
+        meta_store_resolver: Option<MetaStoreResolver>,
     ) -> (Self, mpsc::Receiver<Vec<Vec<Event>>>) {
         // Create a channel with capacity 1
-        let (tx, rx): (mpsc::Sender<Vec<Vec<Event>>>, mpsc::Receiver<Vec<Vec<Event>>>) = mpsc::channel(1);
+        let (tx, rx): (
+            mpsc::Sender<Vec<Vec<Event>>>,
+            mpsc::Receiver<Vec<Vec<Event>>>,
+        ) = mpsc::channel(1);
         let tx = Arc::new(tx);
-        
+
         // Create sink instance (without starting process_events_loop)
         let sink = Self {
             base_path,
@@ -337,19 +351,17 @@ impl TopSQLDeltaLakeSink {
             write_config,
             max_delay_secs,
             storage_options,
+            meta_store_resolver,
             writers: Arc::new(Mutex::new(HashMap::new())),
             tx,
         };
-        
+
         // Return the sink and receiver for testing
         (sink, rx)
     }
 
     /// Process events from channel and write to Delta Lake
-    async fn process_events_loop(
-        &self,
-        mut rx: mpsc::Receiver<Vec<Vec<Event>>>,
-    ) {
+    async fn process_events_loop(&self, mut rx: mpsc::Receiver<Vec<Vec<Event>>>) {
         while let Some(events_vec) = rx.recv().await {
             if let Err(e) = self.process_events(events_vec).await {
                 error!("Failed to process events: {}", e);
@@ -365,36 +377,27 @@ impl TopSQLDeltaLakeSink {
         if events_vec.is_empty() {
             return Ok(());
         }
-        // Group events by table_name (instance_key for topsql/tikv, source_table for topru)
-        let mut table_events: HashMap<String, Vec<Event>> = HashMap::new();
+        let mut table_events: HashMap<WriterKey, Vec<Event>> = HashMap::new();
+        let mut resolved_routes: HashMap<String, Option<KeyspaceRoute>> = HashMap::new();
         for events in events_vec {
             for event in events {
                 if let Event::Log(log_event) = event {
-                    let table_name: Option<String> = log_event
-                        .get(LABEL_INSTANCE_KEY)
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                        .or_else(|| {
-                            // TopRU events lack instance_key; use source_table as grouping key
-                            log_event
-                                .get(LABEL_SOURCE_TABLE)
-                                .and_then(|v| v.as_str())
-                                .filter(|s| *s == SOURCE_TABLE_TOPRU)
-                                .map(|s| s.to_string())
-                        });
-                    if let Some(name) = table_name {
+                    if let Some(writer_key) = self
+                        .resolve_writer_key(&log_event, &mut resolved_routes)
+                        .await
+                    {
                         table_events
-                            .entry(name)
+                            .entry(writer_key)
                             .or_insert_with(Vec::new)
                             .push(Event::Log(log_event));
                     }
                 }
             }
         }
-        // Write table's events
-        for (table_name, mut events) in table_events {
-            self.add_schema_info(&mut events, &table_name);
-            if let Err(e) = self.write_table_events(&table_name, events).await {
+
+        for (writer_key, mut events) in table_events {
+            self.add_schema_info(&mut events, &writer_key.table_name);
+            if let Err(e) = self.write_table_events(&writer_key, events).await {
                 let error_msg = e.to_string();
                 if error_msg.contains("log segment")
                     || error_msg.contains("Invalid table version")
@@ -403,10 +406,15 @@ impl TopSQLDeltaLakeSink {
                 {
                     panic!(
                         "Delta Lake corruption detected for table {}: {}",
-                        table_name, error_msg
+                        writer_key.table_name, error_msg
                     );
                 } else {
-                    error!("Failed to write events to table {}: {}", table_name, e);
+                    error!(
+                        "Failed to write events to table {} at {}: {}",
+                        writer_key.table_name,
+                        writer_key.table_path.display(),
+                        e
+                    );
                 }
             }
         }
@@ -429,63 +437,141 @@ impl TopSQLDeltaLakeSink {
         log.insert("_schema_metadata", serde_json::Value::Object(schema));
     }
 
+    fn extract_table_name(log_event: &LogEvent) -> Option<String> {
+        log_event
+            .get(LABEL_INSTANCE_KEY)
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string())
+            .or_else(|| {
+                log_event
+                    .get(LABEL_SOURCE_TABLE)
+                    .and_then(|value| value.as_str())
+                    .filter(|value| *value == SOURCE_TABLE_TOPRU)
+                    .map(|value| value.to_string())
+            })
+    }
+
+    async fn resolve_writer_key(
+        &self,
+        log_event: &LogEvent,
+        resolved_routes: &mut HashMap<String, Option<KeyspaceRoute>>,
+    ) -> Option<WriterKey> {
+        let table_name = Self::extract_table_name(log_event)?;
+        let route = self
+            .resolve_keyspace_route(log_event, resolved_routes)
+            .await;
+        Some(WriterKey {
+            table_name: table_name.clone(),
+            table_path: self.build_table_path(&table_name, route.as_ref()),
+        })
+    }
+
+    async fn resolve_keyspace_route(
+        &self,
+        log_event: &LogEvent,
+        resolved_routes: &mut HashMap<String, Option<KeyspaceRoute>>,
+    ) -> Option<KeyspaceRoute> {
+        let resolver = self.meta_store_resolver.as_ref()?;
+        let keyspace = log_event
+            .get(LABEL_KEYSPACE)
+            .and_then(|value| value.as_str())?;
+
+        if let Some(route) = resolved_routes.get(keyspace.as_ref()) {
+            return route.clone();
+        }
+
+        let route = match resolver.resolve_keyspace(keyspace.as_ref()).await {
+            Ok(route) => route,
+            Err(error) => {
+                warn!(
+                    "Failed to resolve keyspace {} from meta-store, falling back to base_path: {}",
+                    keyspace, error
+                );
+                None
+            }
+        };
+        resolved_routes.insert(keyspace.to_string(), route.clone());
+        route
+    }
+
+    fn build_table_path(&self, table_name: &str, route: Option<&KeyspaceRoute>) -> PathBuf {
+        let (table_type, table_instance) = Self::table_partition_values(table_name);
+
+        let mut segments = Vec::new();
+        if let Some(route) = route {
+            segments.push(format!("org={}", route.org_id));
+            segments.push(format!("cluster={}", route.cluster_id));
+        }
+        segments.push(format!("type=topsql_{}", table_type));
+        segments.push(format!("instance={}", table_instance));
+
+        let segment_refs: Vec<&str> = segments.iter().map(|segment| segment.as_str()).collect();
+        Self::join_path(&self.base_path, &segment_refs)
+    }
+
+    fn table_partition_values(table_name: &str) -> (&str, &str) {
+        if table_name == SOURCE_TABLE_TOPRU {
+            ("topru", "default")
+        } else {
+            match table_name
+                .strip_prefix("topsql_")
+                .and_then(|rest| rest.split_once('_'))
+            {
+                Some((table_type, table_instance))
+                    if !table_type.is_empty() && !table_instance.is_empty() =>
+                {
+                    (table_type, table_instance)
+                }
+                _ => {
+                    error!(
+                        "Unexpected table_name format (expected `topsql_{{type}}_{{instance}}` or `topsql_topru`): {}",
+                        table_name
+                    );
+                    ("unknown", "unknown")
+                }
+            }
+        }
+    }
+
+    fn join_path(base_path: &PathBuf, segments: &[&str]) -> PathBuf {
+        if base_path.to_string_lossy().starts_with("s3://") {
+            let mut path = base_path
+                .to_string_lossy()
+                .trim_end_matches('/')
+                .to_string();
+            for segment in segments {
+                path.push('/');
+                path.push_str(segment);
+            }
+            PathBuf::from(path)
+        } else {
+            let mut path = base_path.clone();
+            for segment in segments {
+                path = path.join(segment);
+            }
+            path
+        }
+    }
+
     /// Write events to a specific table
     async fn write_table_events(
         &self,
-        table_name: &str,
+        writer_key: &WriterKey,
         events: Vec<Event>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        // Get or create writer for this table
         let mut writers = self.writers.lock().await;
-        let writer = writers.entry(table_name.to_string()).or_insert_with(|| {
-            let (table_type, table_instance) = if table_name == SOURCE_TABLE_TOPRU {
-                ("topru", "default")
-            } else {
-                match table_name
-                    .strip_prefix("topsql_")
-                    .and_then(|rest| rest.split_once('_'))
-                {
-                    Some((t, inst)) if !t.is_empty() && !inst.is_empty() => (t, inst),
-                    _ => {
-                        error!(
-                            "Unexpected table_name format (expected `topsql_{{type}}_{{instance}}` or `topsql_topru`): {}",
-                            table_name
-                        );
-                        ("unknown", "unknown")
-                    }
-                }
-            };
-
-            let type_dir = format!("type=topsql_{}", table_type);
-            let instance_dir = format!("instance={}", table_instance);
-
-            let table_path = if self.base_path.to_string_lossy().starts_with("s3://") {
-                // For S3 paths, build a partition-like directory structure
-                // <base>/topsql/data/type=.../instance=.../<table_name>
-                let base = self.base_path.to_string_lossy();
-                let base = base.trim_end_matches('/');
-                PathBuf::from(format!(
-                    "{}/{}/{}",
-                    base, type_dir, instance_dir
-                ))
-            } else {
-                // For local paths, use join as before
-                self.base_path
-                    .join(&type_dir)
-                    .join(&instance_dir)
-            };
-
+        let writer = writers.entry(writer_key.clone()).or_insert_with(|| {
             let table_config = self
                 .tables
                 .iter()
-                .find(|t| t.name == table_name)
+                .find(|table| table.name == writer_key.table_name)
                 .cloned()
                 .unwrap_or_else(|| DeltaTableConfig {
-                    name: table_name.to_string(),
+                    name: writer_key.table_name.clone(),
                     schema_evolution: Some(true),
                 });
             DeltaLakeWriter::new_with_options(
-                table_path,
+                writer_key.table_path.clone(),
                 table_config,
                 self.write_config.clone(),
                 self.storage_options.clone(),
@@ -493,7 +579,6 @@ impl TopSQLDeltaLakeSink {
             )
         });
 
-        // Write events
         writer.write_events(events).await?;
 
         Ok(())
@@ -537,13 +622,15 @@ impl StreamSink<Event> for TopSQLDeltaLakeSink {
             events_cache.push(events);
 
             // Allow max delay to configured value, continue if not ready to send
-            if events_count + cur_cached_size < sink.write_config.batch_size 
-                && latest_timestamp < oldest_timestamp + sink.max_delay_secs as i64 {
+            if events_count + cur_cached_size < sink.write_config.batch_size
+                && latest_timestamp < oldest_timestamp + sink.max_delay_secs as i64
+            {
                 continue;
             }
 
             // Send events to process_events through channel
-            let should_drop_on_full = latest_timestamp >= oldest_timestamp + sink.max_delay_secs as i64;
+            let should_drop_on_full =
+                latest_timestamp >= oldest_timestamp + sink.max_delay_secs as i64;
             match tx.try_send(events_cache) {
                 Ok(_) => {
                     // Successfully sent, clear the cache
@@ -570,7 +657,7 @@ impl StreamSink<Event> for TopSQLDeltaLakeSink {
                 }
             }
         }
-        
+
         // When the input stream ends, try to send any remaining cached events
         if !events_cache.is_empty() {
             // Send remaining events, wait if channel is full
@@ -579,7 +666,7 @@ impl StreamSink<Event> for TopSQLDeltaLakeSink {
                 error!("Channel closed when flushing remaining events, dropping events");
             }
         }
-        
+
         // Note: We don't drop tx here as it's owned by the sink and may be used by other run() calls
         // The channel will be closed when the sink is dropped
         Ok(())
@@ -601,7 +688,9 @@ mod tests {
         event
     }
 
-    fn create_test_sink_with_receiver(batch_size: usize) -> (TopSQLDeltaLakeSink, mpsc::Receiver<Vec<Vec<Event>>>) {
+    fn create_test_sink_with_receiver(
+        batch_size: usize,
+    ) -> (TopSQLDeltaLakeSink, mpsc::Receiver<Vec<Vec<Event>>>) {
         TopSQLDeltaLakeSink::new_for_test(
             PathBuf::from("/tmp/test"),
             vec![],
@@ -611,52 +700,107 @@ mod tests {
             },
             180, // Use default value for tests
             None,
+            None,
         )
+    }
+
+    #[test]
+    fn test_build_table_path_with_meta_route_for_s3() {
+        let (sink, _) = TopSQLDeltaLakeSink::new_for_test(
+            PathBuf::from("s3://o11y-prod-shared-us-west-2-premium/deltalake"),
+            vec![],
+            WriteConfig {
+                batch_size: 1,
+                timeout_secs: 0,
+            },
+            180,
+            None,
+            None,
+        );
+
+        let table_path = sink.build_table_path(
+            "topsql_tidb_127.0.0.1:10080",
+            Some(&KeyspaceRoute {
+                org_id: "1369847559692509642".to_string(),
+                cluster_id: "10110362358366286743".to_string(),
+            }),
+        );
+
+        assert_eq!(
+            table_path,
+            PathBuf::from(
+                "s3://o11y-prod-shared-us-west-2-premium/deltalake/org=1369847559692509642/cluster=10110362358366286743/type=topsql_tidb/instance=127.0.0.1:10080"
+            )
+        );
+    }
+
+    #[test]
+    fn test_build_table_path_without_meta_route_preserves_existing_layout() {
+        let (sink, _) = TopSQLDeltaLakeSink::new_for_test(
+            PathBuf::from("/tmp/deltalake"),
+            vec![],
+            WriteConfig {
+                batch_size: 1,
+                timeout_secs: 0,
+            },
+            180,
+            None,
+            None,
+        );
+
+        let table_path = sink.build_table_path("topsql_topru", None);
+
+        assert_eq!(
+            table_path,
+            PathBuf::from("/tmp/deltalake/type=topsql_topru/instance=default")
+        );
     }
 
     #[tokio::test]
     async fn test_send_when_batch_size_reached() {
         let batch_size = 5;
         let (sink, mut rx) = create_test_sink_with_receiver(batch_size);
-        
+
         // Create events that will reach batch size
         let events: Vec<Event> = (0..batch_size)
             .map(|i| create_test_event(1000 + i as i64))
             .collect();
-        
+
         let input_stream = stream::iter(events.clone()).boxed();
         let sink_box = Box::new(sink);
-        
+
         // Run the function in a task
-        let run_handle = tokio::spawn(async move {
-            sink_box.run(input_stream).await
-        });
-        
+        let run_handle = tokio::spawn(async move { sink_box.run(input_stream).await });
+
         // Wait a bit for the message to be sent
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
+
         // Verify that a message was sent through the channel
-        let received = tokio::time::timeout(
-            tokio::time::Duration::from_millis(500),
-            rx.recv()
-        ).await;
-        
+        let received =
+            tokio::time::timeout(tokio::time::Duration::from_millis(500), rx.recv()).await;
+
         assert!(received.is_ok(), "Should receive a message from channel");
         if let Ok(Some(events_vec)) = received {
             // Verify the message content
             // Count total events
             let total_events: usize = events_vec.iter().map(|v| v.len()).sum();
-            assert_eq!(total_events, batch_size, "Should receive exactly batch_size events");
-            
+            assert_eq!(
+                total_events, batch_size,
+                "Should receive exactly batch_size events"
+            );
+
             // Verify event structure
             assert!(!events_vec.is_empty(), "Events vector should not be empty");
             for event_batch in &events_vec {
-                assert!(!event_batch.is_empty(), "Each event batch should not be empty");
+                assert!(
+                    !event_batch.is_empty(),
+                    "Each event batch should not be empty"
+                );
             }
         } else {
             panic!("Failed to receive message from channel");
         }
-        
+
         // Wait for run to complete
         let _ = run_handle.await;
     }
@@ -665,44 +809,43 @@ mod tests {
     async fn test_send_when_timeout_reached() {
         let batch_size = 100; // Large batch size so we don't reach it
         let (sink, mut rx) = create_test_sink_with_receiver(batch_size);
-        
+
         // Create events with timestamps that exceed timeout (180 seconds)
         let oldest_ts = 1000;
         let latest_ts = oldest_ts + 181; // Exceeds 180 second timeout
-        
+
         // Create two events: one at the start, one after timeout
-        let events = vec![
-            create_test_event(oldest_ts),
-            create_test_event(latest_ts),
-        ];
-        
+        let events = vec![create_test_event(oldest_ts), create_test_event(latest_ts)];
+
         let input_stream = stream::iter(events.clone()).boxed();
         let sink_box = Box::new(sink);
-        
+
         // Run the function in a task
-        let run_handle = tokio::spawn(async move {
-            sink_box.run(input_stream).await
-        });
-        
+        let run_handle = tokio::spawn(async move { sink_box.run(input_stream).await });
+
         // Wait a bit for the message to be sent
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
+
         // Verify that a message was sent through the channel due to timeout
-        let received = tokio::time::timeout(
-            tokio::time::Duration::from_millis(500),
-            rx.recv()
-        ).await;
-        
-        assert!(received.is_ok(), "Should receive a message from channel due to timeout");
+        let received =
+            tokio::time::timeout(tokio::time::Duration::from_millis(500), rx.recv()).await;
+
+        assert!(
+            received.is_ok(),
+            "Should receive a message from channel due to timeout"
+        );
         if let Ok(Some(events_vec)) = received {
             // Verify the message content
             // Verify events were sent
             let total_events: usize = events_vec.iter().map(|v| v.len()).sum();
-            assert_eq!(total_events, 2, "Should receive both events (oldest and latest)");
+            assert_eq!(
+                total_events, 2,
+                "Should receive both events (oldest and latest)"
+            );
         } else {
             panic!("Failed to receive message from channel");
         }
-        
+
         // Wait for run to complete
         let _ = run_handle.await;
     }
@@ -711,55 +854,60 @@ mod tests {
     async fn test_channel_full_keep_cache_when_not_timeout() {
         let batch_size = 5;
         let (sink, mut rx) = create_test_sink_with_receiver(batch_size);
-        
+
         // Create many events to fill the channel (capacity 1)
         // The first batch will fill the channel, second batch should be kept in cache
         // and retried later
         let events: Vec<Event> = (0..batch_size * 2)
             .map(|i| create_test_event(1000 + i as i64)) // All within timeout window
             .collect();
-        
+
         let input_stream = stream::iter(events.clone()).boxed();
         let sink_box = Box::new(sink);
-        
+
         // Run the function in a task
-        let run_handle = tokio::spawn(async move {
-            sink_box.run(input_stream).await
-        });
-        
+        let run_handle = tokio::spawn(async move { sink_box.run(input_stream).await });
+
         // Don't consume from rx immediately to fill the channel
         // Wait a bit for the first message to be sent
         // The channel should be full now, and subsequent sends should keep data in cache
         // Since we're not consuming, the channel stays full
         // After a bit more time, the run should complete
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
+
         // Now consume the first message
         let first_msg = rx.recv().await;
         assert!(first_msg.is_some(), "Should receive first message");
         if let Some(events_vec) = first_msg {
             // Verify first message content
             let total_events: usize = events_vec.iter().map(|v| v.len()).sum();
-            assert_eq!(total_events, batch_size, "First message should contain batch_size events");
+            assert_eq!(
+                total_events, batch_size,
+                "First message should contain batch_size events"
+            );
         }
-        
+
         // Wait a bit more - the second batch should be sent after channel has space
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
+
         // Check if second message was sent (data was kept in cache and retried)
-        let second_msg = tokio::time::timeout(
-            tokio::time::Duration::from_millis(200),
-            rx.recv()
-        ).await;
-        
+        let second_msg =
+            tokio::time::timeout(tokio::time::Duration::from_millis(200), rx.recv()).await;
+
         // The second batch should eventually be sent (kept in cache and retried)
-        assert!(second_msg.is_ok(), "Should eventually receive second message after retry");
+        assert!(
+            second_msg.is_ok(),
+            "Should eventually receive second message after retry"
+        );
         if let Ok(Some(events_vec)) = second_msg {
             // Verify second message content
             let total_events: usize = events_vec.iter().map(|v| v.len()).sum();
-            assert_eq!(total_events, batch_size, "Second message should contain batch_size events");
+            assert_eq!(
+                total_events, batch_size,
+                "Second message should contain batch_size events"
+            );
         }
-        
+
         // Wait for run to complete
         let _ = run_handle.await;
     }
@@ -768,7 +916,7 @@ mod tests {
     async fn test_channel_full_drop_when_timeout() {
         let batch_size = 5;
         let (sink, mut rx) = create_test_sink_with_receiver(batch_size);
-        
+
         // Create events with timeout: first batch, then events after timeout
         let mut events = vec![];
         // First batch at timestamp 1000
@@ -780,54 +928,59 @@ mod tests {
             events.push(create_test_event(1005 + i as i64));
         }
         events.push(create_test_event(1186));
-        
+
         let input_stream = stream::iter(events.clone()).boxed();
         let sink_box = Box::new(sink);
-        
+
         // Run the function in a task
-        let run_handle = tokio::spawn(async move {
-            sink_box.run(input_stream).await
-        });
-        
+        let run_handle = tokio::spawn(async move { sink_box.run(input_stream).await });
+
         // Don't consume from rx to fill the channel
         // Wait for first message to be sent
         // Channel should be full now
         // When the timeout event arrives and channel is full, data should be dropped
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
+
         // Consume the first message
         let first_msg = rx.recv().await;
         assert!(first_msg.is_some(), "Should receive first message");
         if let Some(events_vec) = first_msg {
             // Verify first message content
             let total_events: usize = events_vec.iter().map(|v| v.len()).sum();
-            assert_eq!(total_events, batch_size, "First message should contain batch_size events");
-            
+            assert_eq!(
+                total_events, batch_size,
+                "First message should contain batch_size events"
+            );
+
             // Verify timestamps are from the first batch (1000-1004)
             for event_batch in &events_vec {
                 for event in event_batch {
                     if let Event::Log(ref log_event) = event {
-                        if let Some(timestamp) = log_event.get("timestamps").and_then(|v| v.as_integer()) {
-                            assert!(timestamp >= 1000 && timestamp < 1000 + batch_size as i64,
-                                    "First message should contain events from first batch");
+                        if let Some(timestamp) =
+                            log_event.get("timestamps").and_then(|v| v.as_integer())
+                        {
+                            assert!(
+                                timestamp >= 1000 && timestamp < 1000 + batch_size as i64,
+                                "First message should contain events from first batch"
+                            );
                         }
                     }
                 }
             }
         }
-        
+
         // Wait a bit more - the timeout event should have been dropped, not sent
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
+
         // Check if a second message was sent (it shouldn't be, as data was dropped)
-        let second_msg = tokio::time::timeout(
-            tokio::time::Duration::from_millis(200),
-            rx.recv()
-        ).await;
+        let second_msg =
+            tokio::time::timeout(tokio::time::Duration::from_millis(200), rx.recv()).await;
         // The second message should NOT be sent because data was dropped due to timeout
-        assert!(second_msg.is_err() || second_msg.unwrap().is_none(), 
-                "Should NOT receive second message as data was dropped due to timeout");
-        
+        assert!(
+            second_msg.is_err() || second_msg.unwrap().is_none(),
+            "Should NOT receive second message as data was dropped due to timeout"
+        );
+
         // Wait for run to complete
         let _ = run_handle.await;
     }
@@ -836,41 +989,38 @@ mod tests {
     async fn test_not_send_when_batch_size_and_timeout_not_reached() {
         let batch_size = 10;
         let (sink, mut rx) = create_test_sink_with_receiver(batch_size);
-        
+
         // Create events that don't reach batch size and don't timeout
-        let events: Vec<Event> = (0..3)
-            .map(|i| create_test_event(1000 + i))
-            .collect();
-        
+        let events: Vec<Event> = (0..3).map(|i| create_test_event(1000 + i)).collect();
+
         let input_stream = stream::iter(events.clone()).boxed();
         let sink_box = Box::new(sink);
-        
+
         // Run the function in a task
-        let run_handle = tokio::spawn(async move {
-            sink_box.run(input_stream).await
-        });
-        
+        let run_handle = tokio::spawn(async move { sink_box.run(input_stream).await });
+
         // Wait for run to complete
         let result = run_handle.await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_ok());
-        
+
         // Verify that no message was sent (data doesn't meet send conditions)
         // Note: When stream ends, remaining data might be flushed, but with only 3 events
         // and batch_size 10, and no timeout, it should not send immediately
         // However, when the stream ends, the loop exits and remaining cache might be sent
         // Let's check if any message was received
-        let received = tokio::time::timeout(
-            tokio::time::Duration::from_millis(200),
-            rx.recv()
-        ).await;
-        
+        let received =
+            tokio::time::timeout(tokio::time::Duration::from_millis(200), rx.recv()).await;
+
         // With the current implementation, when stream ends, remaining cache might be sent
         // So we check if a message was received and verify its content
         if let Ok(Some(events_vec)) = received {
             // Verify the message content
             let total_events: usize = events_vec.iter().map(|v| v.len()).sum();
-            assert_eq!(total_events, 3, "Should receive the 3 events that were cached");
+            assert_eq!(
+                total_events, 3,
+                "Should receive the 3 events that were cached"
+            );
         } else {
             // If no message was received, that's also valid - data wasn't sent
             // This depends on implementation details of when remaining cache is flushed
@@ -881,41 +1031,42 @@ mod tests {
     async fn test_batch_size_sending_behavior() {
         let batch_size = 3;
         let (sink, mut rx) = create_test_sink_with_receiver(batch_size);
-        
+
         // Create exactly batch_size events
         let events: Vec<Event> = (0..batch_size)
             .map(|i| create_test_event(1000 + i as i64))
             .collect();
-        
+
         let input_stream = stream::iter(events.clone()).boxed();
         let sink_box = Box::new(sink);
-        
+
         // Run the function in a task
-        let run_handle = tokio::spawn(async move {
-            sink_box.run(input_stream).await
-        });
-        
+        let run_handle = tokio::spawn(async move { sink_box.run(input_stream).await });
+
         // Wait a bit for the message to be sent
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
+
         // Verify that a message was sent through the channel
-        let received = tokio::time::timeout(
-            tokio::time::Duration::from_millis(500),
-            rx.recv()
-        ).await;
-        
+        let received =
+            tokio::time::timeout(tokio::time::Duration::from_millis(500), rx.recv()).await;
+
         assert!(received.is_ok(), "Should receive a message from channel");
         if let Ok(Some(events_vec)) = received {
             // Verify the message content
             // Count total events
             let total_events: usize = events_vec.iter().map(|v| v.len()).sum();
-            assert_eq!(total_events, batch_size, "Should receive exactly batch_size events");
-            
+            assert_eq!(
+                total_events, batch_size,
+                "Should receive exactly batch_size events"
+            );
+
             // Verify event timestamps
             for event_batch in events_vec {
                 for (i, event) in event_batch.iter().enumerate() {
                     if let Event::Log(ref log_event) = event {
-                        if let Some(timestamp) = log_event.get("timestamps").and_then(|v| v.as_integer()) {
+                        if let Some(timestamp) =
+                            log_event.get("timestamps").and_then(|v| v.as_integer())
+                        {
                             assert_eq!(timestamp, 1000 + i as i64, "Event timestamp should match");
                         }
                     }
@@ -924,7 +1075,7 @@ mod tests {
         } else {
             panic!("Failed to receive message from channel");
         }
-        
+
         // Wait for run to complete
         let _ = run_handle.await;
     }
@@ -933,56 +1084,58 @@ mod tests {
     async fn test_timeout_sending_behavior() {
         let batch_size = 100; // Large batch size
         let (sink, mut rx) = create_test_sink_with_receiver(batch_size);
-        
+
         // Create events with large time gap (exceeding 180 seconds)
         let oldest_ts = 1000;
         let latest_ts = 1181; // 181 seconds later, exceeds timeout
-        let events = vec![
-            create_test_event(oldest_ts),
-            create_test_event(latest_ts),
-        ];
-        
+        let events = vec![create_test_event(oldest_ts), create_test_event(latest_ts)];
+
         let input_stream = stream::iter(events.clone()).boxed();
         let sink_box = Box::new(sink);
-        
+
         // Run the function in a task
-        let run_handle = tokio::spawn(async move {
-            sink_box.run(input_stream).await
-        });
-        
+        let run_handle = tokio::spawn(async move { sink_box.run(input_stream).await });
+
         // Wait a bit for the message to be sent
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
+
         // Verify that a message was sent through the channel due to timeout
-        let received = tokio::time::timeout(
-            tokio::time::Duration::from_millis(500),
-            rx.recv()
-        ).await;
-        
-        assert!(received.is_ok(), "Should receive a message from channel due to timeout");
+        let received =
+            tokio::time::timeout(tokio::time::Duration::from_millis(500), rx.recv()).await;
+
+        assert!(
+            received.is_ok(),
+            "Should receive a message from channel due to timeout"
+        );
         if let Ok(Some(events_vec)) = received {
             // Verify the message content
             // Count total events
             let total_events: usize = events_vec.iter().map(|v| v.len()).sum();
             assert_eq!(total_events, 2, "Should receive both events");
-            
+
             // Verify event timestamps
             let mut timestamps = Vec::new();
             for event_batch in &events_vec {
                 for event in event_batch {
                     if let Event::Log(ref log_event) = event {
-                        if let Some(timestamp) = log_event.get("timestamps").and_then(|v| v.as_integer()) {
+                        if let Some(timestamp) =
+                            log_event.get("timestamps").and_then(|v| v.as_integer())
+                        {
                             timestamps.push(timestamp);
                         }
                     }
                 }
             }
             timestamps.sort();
-            assert_eq!(timestamps, vec![oldest_ts, latest_ts], "Should receive events with correct timestamps");
+            assert_eq!(
+                timestamps,
+                vec![oldest_ts, latest_ts],
+                "Should receive events with correct timestamps"
+            );
         } else {
             panic!("Failed to receive message from channel");
         }
-        
+
         // Wait for run to complete
         let _ = run_handle.await;
     }
@@ -991,51 +1144,51 @@ mod tests {
     async fn test_multiple_batches() {
         let batch_size = 3;
         let (sink, mut rx) = create_test_sink_with_receiver(batch_size);
-        
+
         // Create multiple batches worth of events
         let total_events = batch_size * 3;
         let events: Vec<Event> = (0..total_events)
             .map(|i| create_test_event(1000 + i as i64))
             .collect();
-        
+
         let input_stream = stream::iter(events.clone()).boxed();
         let sink_box = Box::new(sink);
-        
+
         // Run the function in a task
-        let run_handle = tokio::spawn(async move {
-            sink_box.run(input_stream).await
-        });
-        
+        let run_handle = tokio::spawn(async move { sink_box.run(input_stream).await });
+
         // Collect all messages from the channel
         let mut received_messages = Vec::new();
         let expected_batches = (total_events + batch_size - 1) / batch_size; // Ceiling division
-        
+
         // Wait for all batches to be sent
         for _ in 0..expected_batches {
-            let received = tokio::time::timeout(
-                tokio::time::Duration::from_millis(500),
-                rx.recv()
-            ).await;
+            let received =
+                tokio::time::timeout(tokio::time::Duration::from_millis(500), rx.recv()).await;
             if let Ok(Some(msg)) = received {
                 received_messages.push(msg);
             } else {
                 break;
             }
         }
-        
+
         // Verify we received the expected number of batches
         assert!(received_messages.len() >= 1);
         // Verify total events received
-        let total_received: usize = received_messages.iter()
+        let total_received: usize = received_messages
+            .iter()
             .map(|events_vec| events_vec.iter().map(|v| v.len()).sum::<usize>())
             .sum();
-        assert_eq!(total_received, total_events, "Should receive all events across batches");
-        
+        assert_eq!(
+            total_received, total_events,
+            "Should receive all events across batches"
+        );
+
         // Verify each message
         for events_vec in &received_messages {
             assert!(!events_vec.is_empty(), "Each batch should contain events");
         }
-        
+
         // Wait for run to complete
         let _ = run_handle.await;
     }


### PR DESCRIPTION
## Summary
- add `meta_store_addr` to `topsql_data_deltalake` sink config
- resolve keyspace metadata from meta-store and cache `org` and `cluster` routing info
- write TopSQL DeltaLake data under `org={org}/cluster={cluster}` path segments when keyspace metadata is available
- keep the existing path layout as fallback when keyspace metadata cannot be resolved

## Testing
- `cargo check`
- `cargo test --lib common::meta_store::tests::resolve_keyspace_uses_tenant_as_org_id_and_caches_result -- --exact`
- `cargo test --lib build_table_path -- --nocapture`