### PR TITLE
topsql_v2: add TiKV collection toggle

### DIFF
--- a/src/sources/topsql_v2/arch.md
+++ b/src/sources/topsql_v2/arch.md
@@ -45,6 +45,11 @@ pub struct TopSQLV2Config {
 }
 ```
 
+Notable source-specific options:
+
+- `manager_server_address` + `tidb_namespace`: discover active TiDB instances from manager.
+- `enable_tikv_topsql`: when `false`, only TiDB TopSQL is collected; TiKV TopSQL subscriptions are skipped.
+
 ## Data Flow
 
 Same as TopSQL v1 but with improved reliability and performance.

--- a/src/sources/topsql_v2/controller.rs
+++ b/src/sources/topsql_v2/controller.rs
@@ -28,6 +28,7 @@ pub struct Controller {
     init_retry_delay: Duration,
     top_n: usize,
     downsampling_interval: u32,
+    enable_tikv_topsql: bool,
     topru: TopRUConfig,
 
     schema_cache: Arc<SchemaCache>,
@@ -49,6 +50,7 @@ impl Controller {
         init_retry_delay: Duration,
         top_n: usize,
         downsampling_interval: u32,
+        enable_tikv_topsql: bool,
         schema_update_interval: Duration,
         tls_config: Option<TlsConfig>,
         proxy_config: &ProxyConfig,
@@ -81,6 +83,7 @@ impl Controller {
             init_retry_delay,
             top_n,
             downsampling_interval,
+            enable_tikv_topsql,
             topru,
             schema_cache,
             schema_update_interval,
@@ -122,6 +125,8 @@ impl Controller {
         self.topo_fetcher
             .get_up_components(&mut latest_components)
             .await?;
+        latest_components =
+            Self::filter_topsql_components(latest_components, self.enable_tikv_topsql);
 
         let prev_components = self.components.clone();
         let newcomers = latest_components.difference(&prev_components);
@@ -152,6 +157,20 @@ impl Controller {
         }
 
         Ok(has_change)
+    }
+
+    fn filter_topsql_components(
+        components: HashSet<Component>,
+        enable_tikv_topsql: bool,
+    ) -> HashSet<Component> {
+        if enable_tikv_topsql {
+            return components;
+        }
+
+        components
+            .into_iter()
+            .filter(|component| component.instance_type != InstanceType::TiKV)
+            .collect()
     }
 
     async fn update_schema_manager(&mut self, available_components: &HashSet<Component>) {
@@ -341,5 +360,52 @@ impl Controller {
         self.shutdown_notifier.shutdown();
         self.shutdown_notifier.wait_for_exit().await;
         info!(message = "All TopSQL sources have been shut down.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Controller;
+    use crate::common::topology::{Component, InstanceType};
+    use std::collections::HashSet;
+
+    #[test]
+    fn filter_topsql_components_keeps_tikv_when_enabled() {
+        let components = sample_components();
+        let filtered = Controller::filter_topsql_components(components.clone(), true);
+        assert_eq!(filtered.len(), components.len());
+        assert!(filtered
+            .iter()
+            .any(|c| c.instance_type == InstanceType::TiKV));
+    }
+
+    #[test]
+    fn filter_topsql_components_removes_tikv_when_disabled() {
+        let filtered = Controller::filter_topsql_components(sample_components(), false);
+        assert!(filtered
+            .iter()
+            .all(|c| c.instance_type != InstanceType::TiKV));
+        assert!(filtered
+            .iter()
+            .any(|c| c.instance_type == InstanceType::TiDB));
+    }
+
+    fn sample_components() -> HashSet<Component> {
+        HashSet::from([
+            Component {
+                instance_type: InstanceType::TiDB,
+                host: "tidb.example".to_owned(),
+                primary_port: 4000,
+                secondary_port: 10080,
+                instance_name: Some("tidb-0".to_owned()),
+            },
+            Component {
+                instance_type: InstanceType::TiKV,
+                host: "tikv.example".to_owned(),
+                primary_port: 20160,
+                secondary_port: 20180,
+                instance_name: Some("tikv-0".to_owned()),
+            },
+        ])
     }
 }

--- a/src/sources/topsql_v2/mod.rs
+++ b/src/sources/topsql_v2/mod.rs
@@ -87,6 +87,10 @@ pub struct TopSQLConfig {
     #[serde(default = "default_downsampling_interval")]
     pub downsampling_interval: u32,
 
+    /// Whether to collect TopSQL data from TiKV components.
+    #[serde(default = "default_enable_tikv_topsql")]
+    pub enable_tikv_topsql: bool,
+
     /// TopRU (Resource Unit) collection config. Only applies to TiDB upstream.
     #[serde(default)]
     pub topru: TopRUConfig,
@@ -108,6 +112,10 @@ pub const fn default_downsampling_interval() -> u32 {
     60
 }
 
+pub const fn default_enable_tikv_topsql() -> bool {
+    true
+}
+
 impl GenerateConfig for TopSQLConfig {
     fn generate_config() -> toml::Value {
         toml::Value::try_from(Self {
@@ -119,6 +127,7 @@ impl GenerateConfig for TopSQLConfig {
             topology_fetch_interval_seconds: default_topology_fetch_interval(),
             top_n: default_top_n(),
             downsampling_interval: default_downsampling_interval(),
+            enable_tikv_topsql: default_enable_tikv_topsql(),
             topru: TopRUConfig::default(),
         })
         .unwrap()
@@ -139,6 +148,7 @@ impl SourceConfig for TopSQLConfig {
         let init_retry_delay = Duration::from_secs_f64(self.init_retry_delay_seconds);
         let top_n = self.top_n;
         let downsampling_interval = self.downsampling_interval;
+        let enable_tikv_topsql = self.enable_tikv_topsql;
         let topru = self.topru.clone();
         let schema_update_interval = Duration::from_secs(60);
 
@@ -149,6 +159,7 @@ impl SourceConfig for TopSQLConfig {
                 init_retry_delay,
                 top_n,
                 downsampling_interval,
+                enable_tikv_topsql,
                 schema_update_interval,
                 tls,
                 &cx.proxy,


### PR DESCRIPTION
## Summary
- add `enable_tikv_topsql` to `topsql_v2`
- keep current behavior by default with `enable_tikv_topsql = true`
- skip TiKV TopSQL subscriptions when `enable_tikv_topsql = false`

## Testing
- `cargo test filter_topsql_components --lib`