### PR TITLE
0.49 topru

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -112,20 +112,20 @@ jobs:
           find target/aarch64-unknown-linux-gnu/release/deps -name "*.rlib" -not -name "libvector*.rlib" -delete 2>/dev/null || true
           find target/aarch64-unknown-linux-gnu/release/build -type f -name "*.o" -delete 2>/dev/null || true
 
-      - name: Build armv7 binary (standard)
-        timeout-minutes: 90
-        env:
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
-          CARGO_PROFILE_RELEASE_LTO: "thin"
-          CARGO_BUILD_JOBS: 4
-          CARGO_INCREMENTAL: 0
-        run: |
-          echo "Starting armv7 build at $(date)"
-          make build-armv7-unknown-linux-gnueabihf
-          echo "Finished armv7 build at $(date)"
-          # Clean up intermediate files to save disk space
-          find target/armv7-unknown-linux-gnueabihf/release/deps -name "*.rlib" -not -name "libvector*.rlib" -delete 2>/dev/null || true
-          find target/armv7-unknown-linux-gnueabihf/release/build -type f -name "*.o" -delete 2>/dev/null || true
+      # - name: Build armv7 binary (standard)
+      #   timeout-minutes: 90
+      #   env:
+      #     CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
+      #     CARGO_PROFILE_RELEASE_LTO: "thin"
+      #     CARGO_BUILD_JOBS: 4
+      #     CARGO_INCREMENTAL: 0
+      #   run: |
+      #     echo "Starting armv7 build at $(date)"
+      #     make build-armv7-unknown-linux-gnueabihf
+      #     echo "Finished armv7 build at $(date)"
+      #     # Clean up intermediate files to save disk space
+      #     find target/armv7-unknown-linux-gnueabihf/release/deps -name "*.rlib" -not -name "libvector*.rlib" -delete 2>/dev/null || true
+      #     find target/armv7-unknown-linux-gnueabihf/release/build -type f -name "*.o" -delete 2>/dev/null || true
 
       - name: Build and push standard image
         env:
@@ -177,20 +177,20 @@ jobs:
           find target/aarch64-unknown-linux-gnu/release/deps -name "*.rlib" -not -name "libvector*.rlib" -delete 2>/dev/null || true
           find target/aarch64-unknown-linux-gnu/release/build -type f -name "*.o" -delete 2>/dev/null || true
 
-      - name: Build armv7 binary (nextgen)
-        timeout-minutes: 90
-        env:
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
-          CARGO_PROFILE_RELEASE_LTO: "thin"
-          CARGO_BUILD_JOBS: 4
-          CARGO_INCREMENTAL: 0
-        run: |
-          echo "Starting armv7 nextgen build at $(date)"
-          make build-armv7-unknown-linux-gnueabihf-nextgen
-          echo "Finished armv7 nextgen build at $(date)"
-          # Clean up intermediate files to save disk space
-          find target/armv7-unknown-linux-gnueabihf/release/deps -name "*.rlib" -not -name "libvector*.rlib" -delete 2>/dev/null || true
-          find target/armv7-unknown-linux-gnueabihf/release/build -type f -name "*.o" -delete 2>/dev/null || true
+      # - name: Build armv7 binary (nextgen)
+      #   timeout-minutes: 90
+      #   env:
+      #     CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
+      #     CARGO_PROFILE_RELEASE_LTO: "thin"
+      #     CARGO_BUILD_JOBS: 4
+      #     CARGO_INCREMENTAL: 0
+      #   run: |
+      #     echo "Starting armv7 nextgen build at $(date)"
+      #     make build-armv7-unknown-linux-gnueabihf-nextgen
+      #     echo "Finished armv7 nextgen build at $(date)"
+      #     # Clean up intermediate files to save disk space
+      #     find target/armv7-unknown-linux-gnueabihf/release/deps -name "*.rlib" -not -name "libvector*.rlib" -delete 2>/dev/null || true
+      #     find target/armv7-unknown-linux-gnueabihf/release/build -type f -name "*.o" -delete 2>/dev/null || true
 
       - name: Check nextgen binaries before building image
         run: |
@@ -211,18 +211,18 @@ jobs:
           else
             echo "  ❌ NOT FOUND"
           fi
-          echo ""
-          echo "armv7 binary:"
-          if [ -f target/armv7-unknown-linux-gnueabihf/release/vector-nextgen ]; then
-            ls -lh target/armv7-unknown-linux-gnueabihf/release/vector-nextgen
-            echo "  ✅ EXISTS"
-          else
-            echo "  ❌ NOT FOUND"
-          fi
+          # echo ""
+          # echo "armv7 binary:"
+          # if [ -f target/armv7-unknown-linux-gnueabihf/release/vector-nextgen ]; then
+          #   ls -lh target/armv7-unknown-linux-gnueabihf/release/vector-nextgen
+          #   echo "  ✅ EXISTS"
+          # else
+          #   echo "  ❌ NOT FOUND"
+          # fi
           echo ""
           if [ -f target/x86_64-unknown-linux-gnu/release/vector-nextgen ] && \
-             [ -f target/aarch64-unknown-linux-gnu/release/vector-nextgen ] && \
-             [ -f target/armv7-unknown-linux-gnueabihf/release/vector-nextgen ]; then
+             [ -f target/aarch64-unknown-linux-gnu/release/vector-nextgen ]; then
+             # [ -f target/armv7-unknown-linux-gnueabihf/release/vector-nextgen ]; then
             echo "✅ All nextgen binaries exist - Makefile should skip rebuild"
           else
             echo "⚠️ Some binaries missing - Makefile will trigger rebuild"

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ cargo-install-%:
 .PHONY: release-docker
 release-docker: target/x86_64-unknown-linux-gnu/release/vector
 release-docker: target/aarch64-unknown-linux-gnu/release/vector
-release-docker: target/armv7-unknown-linux-gnueabihf/release/vector
+#release-docker: target/armv7-unknown-linux-gnueabihf/release/vector
 	@echo "Releasing docker image..."
 	@scripts/release-docker.sh
 	@echo "Done releasing docker image."
@@ -194,7 +194,7 @@ release-docker: target/armv7-unknown-linux-gnueabihf/release/vector
 .PHONY: release-docker-nextgen
 release-docker-nextgen: target/x86_64-unknown-linux-gnu/release/vector-nextgen
 release-docker-nextgen: target/aarch64-unknown-linux-gnu/release/vector-nextgen
-release-docker-nextgen: target/armv7-unknown-linux-gnueabihf/release/vector-nextgen
+# release-docker-nextgen: target/armv7-unknown-linux-gnueabihf/release/vector-nextgen
 	@echo "Releasing docker image (nextgen mode)..."
 	@NEXTGEN=true scripts/release-docker.sh
 	@echo "Done releasing docker image (nextgen mode)."

--- a/proto/tidb.proto
+++ b/proto/tidb.proto
@@ -62,10 +62,6 @@ message TopRURecord {
   repeated TopRURecordItem items = 5;
 }
 
-message ReportTopRURecords {
-  repeated TopRURecord records = 1;
-}
-
 // TopRURecordItem represents statistics within a single time bucket.
 message TopRURecordItem {
   uint64 timestamp_sec = 1; // timestamp in second
@@ -117,6 +113,6 @@ message TopSQLSubResponse {
     TopSQLRecord record = 1;
     SQLMeta sql_meta = 2;
     PlanMeta plan_meta = 3;
-    ReportTopRURecords top_ru_records = 4;
+    TopRURecord ru_record = 4;
   }
 }

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -35,7 +35,7 @@ BINARY_NAME="${NEXTGEN:+vector-nextgen}"
 BINARY_NAME="${BINARY_NAME:-vector}"
 cp target/x86_64-unknown-linux-gnu/release/${BINARY_NAME} "$WORK_DIR"/vector-amd64
 cp target/aarch64-unknown-linux-gnu/release/${BINARY_NAME} "$WORK_DIR"/vector-arm64
-cp target/armv7-unknown-linux-gnueabihf/release/${BINARY_NAME} "$WORK_DIR"/vector-arm
+# cp target/armv7-unknown-linux-gnueabihf/release/${BINARY_NAME} "$WORK_DIR"/vector-arm
 # cp config/vector.toml "$WORK_DIR"
 
 VERSION="${VECTOR_VERSION:-"$(scripts/version.sh)"}"
@@ -45,7 +45,7 @@ BASE=debian
 TAG="${TAG:-$REPO:$VERSION-$BASE}"
 DOCKERFILE="scripts/docker/Dockerfile"
 
-PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
-#PLATFORMS="linux/amd64,linux/arm64"
+#PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
+PLATFORMS="linux/amd64,linux/arm64"
 echo "Building docker image: $TAG for $PLATFORMS"
 docker buildx build --push --platform="$PLATFORMS" -t "$TAG" -f "$DOCKERFILE" "$WORK_DIR"

--- a/src/sinks/topsql_data_deltalake/processor.rs
+++ b/src/sinks/topsql_data_deltalake/processor.rs
@@ -456,12 +456,12 @@ impl TopSQLDeltaLakeSink {
                 }
             };
 
-            let type_dir = format!("type=topsql_{}", table_type);
+            let type_dir = format!("component={}", table_type);
             let instance_dir = format!("instance={}", table_instance);
 
             let table_path = if self.base_path.to_string_lossy().starts_with("s3://") {
                 // For S3 paths, build a partition-like directory structure
-                // <base>/topsql/data/type=.../instance=.../<table_name>
+                // <base>/topsql/data/component=.../instance=.../<table_name>
                 let base = self.base_path.to_string_lossy();
                 let base = base.trim_end_matches('/');
                 PathBuf::from(format!(

--- a/src/sinks/topsql_meta_deltalake/processor.rs
+++ b/src/sinks/topsql_meta_deltalake/processor.rs
@@ -410,13 +410,13 @@ impl TopSQLDeltaLakeSink {
             let table_path = if self.base_path.to_string_lossy().starts_with("s3://") {
                 // For S3 paths, append the table name to the S3 path
                 PathBuf::from(format!(
-                    "{}/type={}",
+                    "{}/component={}",
                     self.base_path.to_string_lossy(),
                     table_name
                 ))
             } else {
                 // For local paths, use join as before
-                self.base_path.join(format!("type={}", table_name))
+                self.base_path.join(format!("component={}", table_name))
             };
 
             let table_config = self

--- a/src/sources/conprof/tools/jeprof_native.rs
+++ b/src/sources/conprof/tools/jeprof_native.rs
@@ -41,10 +41,16 @@ fn address_sub_one(hex_addr: &str) -> Option<String> {
     Some(format!("{:0width$x}", r, width = ADDRESS_LENGTH))
 }
 
-/// Parse pprof heap profile text format and collect unique PCs (call sites).
-/// Lines: optional % commands, then header "heap profile: ...", then
-///   "\s*(\d+):\s*(\d+)\s*\[\s*(\d+):\s*(\d+)\]\s*@\s*(.*)" with addresses after @.
-/// FixCallerAddresses: subtract 1 from each address except the first.
+/// Parse pprof heap text format and collect unique PCs (call sites).
+///
+/// Supports both:
+/// 1) Heap profile entries:
+///    "\s*(\d+):\s*(\d+)\s*\[\s*(\d+):\s*(\d+)\]\s*@\s*(addr1 addr2 ...)"
+/// 2) Remote threaded heap v2 ("heap_v2/<rate>"):
+///    - first section header: "heap_v2/<rate>"
+///    - stack is provided on separate lines starting with "@ addr1 addr2 ..."
+///
+/// FixCallerAddresses (jeprof): subtract 1 from each address except the first.
 /// Returns sorted unique PCs as 0-padded hex strings (no 0x prefix, for consistent ordering).
 fn parse_heap_profile_for_pcs(body: &[u8]) -> Option<Vec<String>> {
     let text = str::from_utf8(body).ok()?;
@@ -60,7 +66,10 @@ fn parse_heap_profile_for_pcs(body: &[u8]) -> Option<Vec<String>> {
             continue;
         }
         if !past_header {
-            if line.starts_with("heap profile:") || line.starts_with("heap ") {
+            if line.starts_with("heap profile:")
+                || line.starts_with("heap ")
+                || line.starts_with("heap_v2/")
+            {
                 past_header = true;
             }
             continue;
@@ -68,25 +77,52 @@ fn parse_heap_profile_for_pcs(body: &[u8]) -> Option<Vec<String>> {
         if line.starts_with("MAPPED_LIBRARIES:") || line.starts_with("--- Memory map:") {
             break;
         }
-        // Match: optional whitespace, count1: bytes1 [ count2: bytes2 ] @ addr1 addr2 ...
+
         let rest = line.trim_start();
-        let at_pos = rest.find(" @ ")?;
-        let stack_part = rest.get(at_pos + 3..)?.trim();
-        if stack_part.is_empty() {
+
+        // heap_v2 threaded format:
+        // "@ addr1 addr2 ..." (stack for the following t*: lines)
+        if rest.starts_with('@') {
+            let stack_part = rest.trim_start_matches('@').trim();
+            if stack_part.is_empty() {
+                continue;
+            }
+            let addrs: Vec<&str> = stack_part.split_whitespace().collect();
+            if addrs.is_empty() {
+                continue;
+            }
+            for (i, addr) in addrs.iter().enumerate() {
+                let extended = hex_extend(addr)?;
+                let fixed = if i == 0 {
+                    extended
+                } else {
+                    address_sub_one(&extended).unwrap_or(extended)
+                };
+                pcs.insert(fixed);
+            }
             continue;
         }
-        let addrs: Vec<&str> = stack_part.split_whitespace().collect();
-        if addrs.is_empty() {
-            continue;
-        }
-        for (i, addr) in addrs.iter().enumerate() {
-            let extended = hex_extend(addr)?;
-            let fixed = if i == 0 {
-                extended
-            } else {
-                address_sub_one(&extended).unwrap_or(extended)
-            };
-            pcs.insert(fixed);
+
+        // heap profile entry format:
+        // optional whitespace, count1: bytes1 [ count2: bytes2 ] @ addr1 addr2 ...
+        if let Some(at_pos) = rest.find(" @ ") {
+            let stack_part = rest.get(at_pos + 3..)?.trim();
+            if stack_part.is_empty() {
+                continue;
+            }
+            let addrs: Vec<&str> = stack_part.split_whitespace().collect();
+            if addrs.is_empty() {
+                continue;
+            }
+            for (i, addr) in addrs.iter().enumerate() {
+                let extended = hex_extend(addr)?;
+                let fixed = if i == 0 {
+                    extended
+                } else {
+                    address_sub_one(&extended).unwrap_or(extended)
+                };
+                pcs.insert(fixed);
+            }
         }
     }
 
@@ -278,6 +314,20 @@ mod tests {
         let pcs = parse_heap_profile_for_pcs(body).unwrap();
         assert!(!pcs.is_empty());
         assert!(pcs.iter().any(|s| s.contains("12345") || s.ends_with("12345")));
+    }
+
+    #[test]
+    fn test_parse_heap_v2_at_lines() {
+        let body = b"heap_v2/524288
+  t*: 1: 2 [ 0: 0]
+@ 0x12345 0x67890 0xabc
+";
+        let pcs = parse_heap_profile_for_pcs(body).unwrap();
+        assert!(pcs.len() >= 2);
+        // First addr is not FixCallerAddresses-adjusted.
+        assert!(pcs.iter().any(|s| s.ends_with("12345")));
+        // Second+ are adjusted (subtract 1), so 0x67890 -> 0x6788f
+        assert!(pcs.iter().any(|s| s.ends_with("6788f")));
     }
 
     #[test]

--- a/src/sources/conprof/tools/jeprof_native.rs
+++ b/src/sources/conprof/tools/jeprof_native.rs
@@ -187,14 +187,16 @@ fn build_symbolized_output(
     out.extend_from_slice(program_name.as_bytes());
     out.push(b'\n');
     for pc in pcs {
-        let sym = symbol_map
-            .get(pc)
-            .map(|s| s.as_str())
-            .unwrap_or("0x");
         out.extend_from_slice(b"0x");
         out.extend_from_slice(pc.as_bytes());
         out.push(b' ');
-        out.extend_from_slice(sym.as_bytes());
+        if let Some(s) = symbol_map.get(pc) {
+            out.extend_from_slice(s.as_bytes());
+        } else {
+            // Match Perl: when symbol is missing, use address as the symbol (0x<pc>)
+            out.extend_from_slice(b"0x");
+            out.extend_from_slice(pc.as_bytes());
+        }
         out.push(b'\n');
     }
     out.extend_from_slice(b"---\n");
@@ -205,12 +207,15 @@ fn build_symbolized_output(
 
 /// Full native jeprof --raw flow: GET heap -> parse PCs -> fetch symbols + cmdline -> build output.
 /// If profile is binary or parsing yields no PCs, returns raw body only (no symbol header).
+/// Requesting Accept: text/plain ensures the server returns pprof text format (e.g. "heap profile: ... @ 0x...")
+/// so we can parse PCs and add the symbol header; otherwise some servers return jemalloc heap_v2 and we skip symbolization.
 pub async fn fetch_raw_symbolized(
     client: &Client,
     heap_url: &str,
 ) -> Result<Vec<u8>, String> {
     let body = client
         .get(heap_url)
+        .header("Accept", "text/plain")
         .send()
         .await
         .map_err(|e| format!("http request failed: {}", e))?;

--- a/src/sources/topsql/upstream/tidb/parser.rs
+++ b/src/sources/topsql/upstream/tidb/parser.rs
@@ -37,7 +37,7 @@ impl UpstreamEventParser for TopSqlSubResponseParser {
             }
             Some(RespOneof::SqlMeta(sql_meta)) => Self::parse_tidb_sql_meta(sql_meta),
             Some(RespOneof::PlanMeta(plan_meta)) => Self::parse_tidb_plan_meta(plan_meta),
-            Some(RespOneof::TopRuRecords(_)) => vec![], // TODO: implement TopRURecords parsing
+            Some(RespOneof::RuRecord(_)) => vec![], // TODO: implement TopRU record parsing
             None => vec![],
         }
     }

--- a/src/sources/topsql/upstream/tidb/proto.rs
+++ b/src/sources/topsql/upstream/tidb/proto.rs
@@ -24,9 +24,7 @@ impl ByteSizeOf for RespOneof {
             RespOneof::PlanMeta(plan_meta) => {
                 plan_meta.plan_digest.len() + plan_meta.normalized_plan.len()
             }
-            RespOneof::TopRuRecords(top_ru_records) => {
-                top_ru_records.records.size_of()
-            }
+            RespOneof::RuRecord(ru_record) => ru_record.size_of(),
         }
     }
 }

--- a/src/sources/topsql_v2/upstream/tidb/parser.rs
+++ b/src/sources/topsql_v2/upstream/tidb/parser.rs
@@ -36,7 +36,7 @@ impl UpstreamEventParser for TopSqlSubResponseParser {
             }
             Some(RespOneof::SqlMeta(sql_meta)) => Self::parse_tidb_sql_meta(sql_meta),
             Some(RespOneof::PlanMeta(plan_meta)) => Self::parse_tidb_plan_meta(plan_meta),
-            Some(RespOneof::TopRuRecords(top_ru_records)) => Self::parse_top_ru_records(top_ru_records),
+            Some(RespOneof::RuRecord(ru_record)) => Self::parse_top_ru_record(ru_record),
             None => vec![],
         }
     }
@@ -320,52 +320,48 @@ impl TopSqlSubResponseParser {
         events
     }
 
-    fn parse_top_ru_records(top_ru_records: crate::sources::topsql_v2::upstream::tidb::proto::ReportTopRuRecords) -> Vec<LogEvent> {
+    fn parse_top_ru_record(record: crate::sources::topsql_v2::upstream::tidb::proto::TopRuRecord) -> Vec<LogEvent> {
         let mut events = vec![];
         let mut date = String::new();
-        
-        for record in top_ru_records.records {
-            let mut keyspace_name_str = "".to_string();
-            if !record.keyspace_name.is_empty() {
-                if let Ok(ks) = String::from_utf8(record.keyspace_name.clone()) {
-                    keyspace_name_str = ks;
-                }
-            }
-            
-            for item in record.items {
-                let mut event = Event::Log(LogEvent::default());
-                let log = event.as_mut_log();
 
-                // Add metadata with Vector prefix
-                log.insert(LABEL_SOURCE_TABLE, SOURCE_TABLE_TOPRU);
-                log.insert(LABEL_TIMESTAMPS, LogValue::from(item.timestamp_sec));
-                
-                if date.is_empty() {
-                    date = chrono::DateTime::from_timestamp(item.timestamp_sec as i64, 0)
-                        .map(|dt| dt.format("%Y-%m-%d").to_string())
-                        .unwrap_or_else(|| "1970-01-01".to_string());
-                }
-                log.insert(LABEL_DATE, LogValue::from(date.clone()));
-                
-                // Note: TopRU doesn't use instance_key - all instances write to same table
-                if !keyspace_name_str.is_empty() {
-                    log.insert(LABEL_KEYSPACE, keyspace_name_str.clone());
-                }
-                log.insert(LABEL_USER, record.user.clone());
-                log.insert(
-                    LABEL_SQL_DIGEST,
-                    hex::encode_upper(record.sql_digest.clone()),
-                );
-                log.insert(
-                    LABEL_PLAN_DIGEST,
-                    hex::encode_upper(record.plan_digest.clone()),
-                );
-                log.insert(METRIC_NAME_TOTAL_RU, LogValue::from(item.total_ru));
-                log.insert(METRIC_NAME_EXEC_COUNT, LogValue::from(item.exec_count));
-                log.insert(METRIC_NAME_EXEC_DURATION, LogValue::from(item.exec_duration));
-                
-                events.push(event.into_log());
+        let mut keyspace_name_str = "".to_string();
+        if !record.keyspace_name.is_empty() {
+            if let Ok(ks) = String::from_utf8(record.keyspace_name.clone()) {
+                keyspace_name_str = ks;
             }
+        }
+
+        for item in record.items {
+            let mut event = Event::Log(LogEvent::default());
+            let log = event.as_mut_log();
+
+            log.insert(LABEL_SOURCE_TABLE, SOURCE_TABLE_TOPRU);
+            log.insert(LABEL_TIMESTAMPS, LogValue::from(item.timestamp_sec));
+
+            if date.is_empty() {
+                date = chrono::DateTime::from_timestamp(item.timestamp_sec as i64, 0)
+                    .map(|dt| dt.format("%Y-%m-%d").to_string())
+                    .unwrap_or_else(|| "1970-01-01".to_string());
+            }
+            log.insert(LABEL_DATE, LogValue::from(date.clone()));
+
+            if !keyspace_name_str.is_empty() {
+                log.insert(LABEL_KEYSPACE, keyspace_name_str.clone());
+            }
+            log.insert(LABEL_USER, record.user.clone());
+            log.insert(
+                LABEL_SQL_DIGEST,
+                hex::encode_upper(record.sql_digest.clone()),
+            );
+            log.insert(
+                LABEL_PLAN_DIGEST,
+                hex::encode_upper(record.plan_digest.clone()),
+            );
+            log.insert(METRIC_NAME_TOTAL_RU, LogValue::from(item.total_ru));
+            log.insert(METRIC_NAME_EXEC_COUNT, LogValue::from(item.exec_count));
+            log.insert(METRIC_NAME_EXEC_DURATION, LogValue::from(item.exec_duration));
+
+            events.push(event.into_log());
         }
         events
     }
@@ -374,7 +370,7 @@ impl TopSqlSubResponseParser {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sources::topsql_v2::upstream::tidb::proto::{TopSqlRecordItem, TopRuRecord, TopRuRecordItem, ReportTopRuRecords};
+    use crate::sources::topsql_v2::upstream::tidb::proto::{TopSqlRecordItem, TopRuRecord, TopRuRecordItem};
 
     const MOCK_RECORDS: &'static str = include_str!("testdata/mock-records.json");
 
@@ -885,33 +881,29 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_top_ru_records() {
-        let top_ru_records = ReportTopRuRecords {
-            records: vec![
-                TopRuRecord {
-                    keyspace_name: b"test_keyspace".to_vec(),
-                    user: "test_user".to_string(),
-                    sql_digest: b"sql_digest_123".to_vec(),
-                    plan_digest: b"plan_digest_456".to_vec(),
-                    items: vec![
-                        TopRuRecordItem {
-                            timestamp_sec: 1709646900,
-                            total_ru: 100.5,
-                            exec_count: 10,
-                            exec_duration: 50000000, // 50ms in nanoseconds
-                        },
-                        TopRuRecordItem {
-                            timestamp_sec: 1709646960,
-                            total_ru: 200.0,
-                            exec_count: 20,
-                            exec_duration: 100000000, // 100ms in nanoseconds
-                        },
-                    ],
+    fn test_parse_top_ru_record() {
+        let ru_record = TopRuRecord {
+            keyspace_name: b"test_keyspace".to_vec(),
+            user: "test_user".to_string(),
+            sql_digest: b"sql_digest_123".to_vec(),
+            plan_digest: b"plan_digest_456".to_vec(),
+            items: vec![
+                TopRuRecordItem {
+                    timestamp_sec: 1709646900,
+                    total_ru: 100.5,
+                    exec_count: 10,
+                    exec_duration: 50000000, // 50ms in nanoseconds
+                },
+                TopRuRecordItem {
+                    timestamp_sec: 1709646960,
+                    total_ru: 200.0,
+                    exec_count: 20,
+                    exec_duration: 100000000, // 100ms in nanoseconds
                 },
             ],
         };
 
-        let events = TopSqlSubResponseParser::parse_top_ru_records(top_ru_records);
+        let events = TopSqlSubResponseParser::parse_top_ru_record(ru_record);
         assert_eq!(events.len(), 2);
 
         // Check first event

--- a/src/sources/topsql_v2/upstream/tidb/proto.rs
+++ b/src/sources/topsql_v2/upstream/tidb/proto.rs
@@ -24,9 +24,7 @@ impl ByteSizeOf for RespOneof {
             RespOneof::PlanMeta(plan_meta) => {
                 plan_meta.plan_digest.len() + plan_meta.normalized_plan.len()
             }
-            RespOneof::TopRuRecords(top_ru_records) => {
-                top_ru_records.records.size_of()
-            }
+            RespOneof::RuRecord(ru_record) => ru_record.size_of(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Merges **`0.49-topru`** into **`0.49`**, bringing TopRU-related protocol/parser updates, continuous profiling (`jeprof`) improvements for native heap profiles, and small CI/build and sink adjustments.

## Motivation

- Align TopSQL upstream parsing and protobuf definitions with the current TiDB/TopRU expectations (`tidb.proto` and generated/parser code).
- Extend native `jeprof` tooling to support **`heap_v2`** profiles and fix earlier native jeprof issues.
- Simplify release/CI matrix by **dropping ARM Vector builds first** (see CI/Makefile changes), and keep Docker release scripts in sync.

## Changes

### TopSQL / TopRU (upstream)

- Update **`proto/tidb.proto`** and corresponding **`proto`/`parser`** usage in **`topsql`** and **`topsql_v2`** (`src/sources/topsql/upstream/tidb/*`, `src/sources/topsql_v2/upstream/tidb/*`).
- Refactor TopSQL v2 TiDB parser for consistency with the updated proto and clearer handling of record types (including **`component`** vs legacy **`type`** naming where applicable).

### Conprof / jeprof (native)

- **`src/sources/conprof/tools/jeprof_native.rs`**: native jeprof support for **`heap_v2`**, plus fixes for native jeprof behavior.

### Sinks (minor)

- **`topsql_data_deltalake`** and **`topsql_meta_deltalake`** processors: small aligned updates (4 lines each in current diff).

### CI / build / release

- **`.github/workflows/build_image.yml`**: workflow updates (including ARM-related removal per commit intent).
- **`Makefile`**, **`scripts/release-docker.sh`**: aligned build/release adjustments.

## Commits (high level)

| Commit     | Description |
|-----------|-------------|
| `7ce3e3e` | Fix TopRU / TiDB proto and TopSQL(v2) parser alignment |
| `387215d` | Change record field to `component` where appropriate |
| `6aaf6af` | Fix native jeprof issue |
| `8667b91` | Remove ARM vector build first (CI/Makefile) |
| `ddbe3a1` | Native jeprof: `heap_v2` support |

## Testing

- [ ] `cargo test` / project `make test` (or CI green on this branch)
- [ ] Smoke: TopSQL v2 pipeline against TiDB with TopRU-enabled workloads (if applicable)
- [ ] Conprof: ingest **`heap_v2`** jeprof sample and verify native conversion path

## Risk / rollout notes

- **Proto/parser changes** may affect compatibility with specific TiDB builds; confirm the target cluster’s TopSQL gRPC/proto version matches this branch.
- **CI/build matrix** change (ARM Vector removed): confirm release and image consumers no longer rely on those artifacts.


