### PR TITLE
fix(deltalake): use abfss:// instead of az:// for Azure Blob Storage

### DIFF
--- a/src/common/deltalake_s3.rs
+++ b/src/common/deltalake_s3.rs
@@ -539,7 +539,7 @@ pub fn build_healthcheck(
         return Ok(healthcheck);
     }
 
-    // For cloud storage paths (az://, gs://) without S3 service,
+    // For cloud storage paths (abfss://, gs://) without S3 service,
     // use a simplified healthcheck - connectivity will be verified during writes
     if is_cloud_path {
         let base_path_owned = base_path.to_string();

--- a/src/common/deltalake_writer/arch.md
+++ b/src/common/deltalake_writer/arch.md
@@ -57,7 +57,7 @@ Used by multiple sinks:
 - **topsql_data_deltalake**: TopSQL data sink
 - **topsql_meta_deltalake**: TopSQL metadata sink
 
-- Support for S3 (s3://) and Azure Blob (az://) storage backends
+- Support for S3 (s3://) and Azure Blob (abfss://) storage backends
 
 ## Data Conversion
 
@@ -186,7 +186,7 @@ The Azure Blob Storage backend supports multiple authentication methods:
 [sinks.deltalake]
 type = "deltalake"
 inputs = ["your_source"]
-base_path = "az://container-name/path/to/delta-tables"
+base_path = "abfss://container-name/path/to/delta-tables"
 batch_size = 1000
 timeout_secs = 30
 ```

--- a/src/common/deltalake_writer/delta_ops.rs
+++ b/src/common/deltalake_writer/delta_ops.rs
@@ -165,7 +165,7 @@ impl DeltaOpsManager {
         let table_uri = {
             let path_str = table_path.to_string_lossy();
             if path_str.starts_with("s3://")
-                || path_str.starts_with("az://")
+                || path_str.starts_with("abfss://")
                 || path_str.starts_with("gs://")
             {
                 // Cloud storage paths already have protocol prefix

--- a/src/common/deltalake_writer/mod.rs
+++ b/src/common/deltalake_writer/mod.rs
@@ -96,7 +96,7 @@ impl DeltaLakeWriter {
         if path_str.starts_with("s3://") {
             deltalake::aws::register_handlers(None);
             info!("Registered Delta Lake S3 handlers for path: {}", path_str);
-        } else if path_str.starts_with("az://") {
+        } else if path_str.starts_with("abfss://") {
             deltalake::azure::register_handlers(None);
             info!(
                 "Registered Delta Lake Azure handlers for path: {}",

--- a/src/sinks/deltalake/mod.rs
+++ b/src/sinks/deltalake/mod.rs
@@ -114,7 +114,7 @@ impl SinkConfig for DeltaLakeConfig {
         );
 
         let is_cloud_path = self.base_path.starts_with("s3://")
-            || self.base_path.starts_with("az://")
+            || self.base_path.starts_with("abfss://")
             || self.base_path.starts_with("gs://");
 
         // Create S3 service if bucket is configured (S3/OSS only)
@@ -699,11 +699,7 @@ mod tests {
         let partition_dirs: Vec<_> = fs::read_dir(&base_path)
             .expect("Failed to read table directory")
             .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .starts_with("date=")
-            })
+            .filter(|e| e.file_name().to_string_lossy().starts_with("date="))
             .collect();
 
         assert!(

--- a/src/sinks/deltalake/processor.rs
+++ b/src/sinks/deltalake/processor.rs
@@ -99,7 +99,7 @@ impl DeltaLakeSink {
         let writer = writers.entry(table_name.to_string()).or_insert_with(|| {
             let path_str = self.base_path.to_string_lossy();
             let is_cloud_path = path_str.starts_with("s3://")
-                || path_str.starts_with("az://")
+                || path_str.starts_with("abfss://")
                 || path_str.starts_with("gs://");
 
             let table_path = if is_cloud_path {
@@ -119,10 +119,7 @@ impl DeltaLakeSink {
                 .find(|t| t.name == table_name)
                 .cloned()
                 .unwrap_or_else(|| {
-                    info!(
-                        "Creating default table config for {}",
-                        table_name
-                    );
+                    info!("Creating default table config for {}", table_name);
                     DeltaTableConfig {
                         name: table_name.to_string(),
                         schema_evolution: Some(true),

--- a/src/sinks/topsql_data_deltalake/mod.rs
+++ b/src/sinks/topsql_data_deltalake/mod.rs
@@ -123,7 +123,7 @@ impl SinkConfig for DeltaLakeConfig {
         );
 
         let is_cloud_path = self.base_path.starts_with("s3://")
-            || self.base_path.starts_with("az://")
+            || self.base_path.starts_with("abfss://")
             || self.base_path.starts_with("gs://");
 
         // Create S3 service if bucket is configured (S3/OSS only)

--- a/src/sinks/topsql_data_deltalake/processor.rs
+++ b/src/sinks/topsql_data_deltalake/processor.rs
@@ -459,7 +459,7 @@ impl TopSQLDeltaLakeSink {
             let instance_dir = format!("instance={}", table_instance);
 
             let table_path = if self.base_path.to_string_lossy().starts_with("s3://")
-                || self.base_path.to_string_lossy().starts_with("az://")
+                || self.base_path.to_string_lossy().starts_with("abfss://")
                 || self.base_path.to_string_lossy().starts_with("gs://")
             {
                 // For cloud paths, build a partition-like directory structure

--- a/src/sinks/topsql_meta_deltalake/mod.rs
+++ b/src/sinks/topsql_meta_deltalake/mod.rs
@@ -132,7 +132,7 @@ impl SinkConfig for DeltaLakeConfig {
         );
 
         let is_cloud_path = self.base_path.starts_with("s3://")
-            || self.base_path.starts_with("az://")
+            || self.base_path.starts_with("abfss://")
             || self.base_path.starts_with("gs://");
 
         // Create S3 service if bucket is configured (S3/OSS only)

--- a/src/sinks/topsql_meta_deltalake/processor.rs
+++ b/src/sinks/topsql_meta_deltalake/processor.rs
@@ -426,7 +426,7 @@ impl TopSQLDeltaLakeSink {
         let mut writers = self.writers.lock().await;
         let writer = writers.entry(table_name.to_string()).or_insert_with(|| {
             let table_path = if self.base_path.to_string_lossy().starts_with("s3://")
-                || self.base_path.to_string_lossy().starts_with("az://")
+                || self.base_path.to_string_lossy().starts_with("abfss://")
                 || self.base_path.to_string_lossy().starts_with("gs://")
             {
                 // For cloud paths, append the table name to the cloud path


### PR DESCRIPTION
The az:// URL scheme causes path inconsistency in deltalake-core 0.29.4: object_store's ObjectStoreScheme::parse does strip_bucket for az:// but not for abfss://, leading to mismatched paths between prefixed_store (write) and root_store/kernel (read). This results in 'version 0 already exists' errors when writing to existing Delta tables on Azure.

Switch all Azure cloud path detection from az:// to abfss:// which does not have the strip_bucket behavior, ensuring consistent paths for both read and write operations.

bug fix ref: https://github.com/apache/arrow-rs-object-store/commit/9f4f679116d7291923e6d07d4142d8f74948bcd5