### PR TITLE
fix(deltalake): detect and apply compatible schema evolution

### DIFF
--- a/src/common/deltalake_writer/mod.rs
+++ b/src/common/deltalake_writer/mod.rs
@@ -141,6 +141,30 @@ impl DeltaLakeWriter {
             _ => self.table_config.name.clone(),
         };
 
+        // -------------------------------------------------------------------
+        // Schema evolution: detect compatible new-column additions and reset
+        // the cached schemas so the next RecordBatch includes them.
+        // Drops and type changes are blocked inside check_schema_evolution.
+        // -------------------------------------------------------------------
+        if let (Some(Event::Log(log_event)), Some(ref fixed_schema)) =
+            (events.first(), &self.fixed_arrow_schema)
+        {
+            if let schema::EvolutionResult::Compatible {
+                incoming_count,
+                fixed_count,
+            } = self
+                .schema_manager
+                .check_schema_evolution(log_event, fixed_schema)
+            {
+                info!(
+                    "Compatible schema evolution detected for table {}: {} data fields incoming, {} in fixed cache. New columns will be merged.",
+                    table_name, incoming_count, fixed_count
+                );
+                self.fixed_arrow_schema = None;
+                self.schema_manager.reset_schema_cache(&table_name);
+            }
+        }
+
         // Convert events to RecordBatch
         let (record_batch, schema) = EventConverter::events_to_record_batch(
             &mut self.schema_manager,

--- a/src/common/deltalake_writer/schema.rs
+++ b/src/common/deltalake_writer/schema.rs
@@ -6,6 +6,16 @@ use vector_lib::event::{Event, LogEvent, Value as LogValue};
 
 use super::types::TypeConverter;
 
+/// Result of a schema evolution compatibility check.
+pub enum EvolutionResult {
+    /// All existing columns are present with compatible types AND at least one new column was added.
+    Compatible { incoming_count: usize, fixed_count: usize },
+    /// A column was dropped or changed type; reset is blocked to protect the table.
+    Blocked,
+    /// Schema is unchanged (same column count as fixed schema).
+    Unchanged,
+}
+
 /// Schema metadata extracted from events
 #[derive(Debug, Clone)]
 pub struct SchemaMetadata {
@@ -244,11 +254,85 @@ impl SchemaManager {
         self.type_converter.infer_arrow_type(field_name, value)
     }
 
+    /// Check whether incoming events carry a compatible schema evolution (new columns only).
+    ///
+    /// Compares the MySQL field types in `_schema_metadata` against the Arrow types in
+    /// `fixed_schema`. Returns `EvolutionResult::Compatible` only when every existing
+    /// column is still present with the same Arrow type AND at least one new column has
+    /// been added. Returns `Blocked` on any drop or type change so the caller can avoid
+    /// corrupting the table.
+    pub fn check_schema_evolution(
+        &self,
+        log_event: &LogEvent,
+        fixed_schema: &Schema,
+    ) -> EvolutionResult {
+        let incoming_meta: HashMap<String, String> = log_event
+            .get("_schema_metadata")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .filter(|(k, _)| !k.starts_with('_'))
+                    .filter_map(|(k, v)| {
+                        v.get("mysql_type")
+                            .and_then(|t| t.as_str())
+                            .map(|t| (k.as_str().to_string(), t.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Data fields only — exclude Vector system fields and the partition date column.
+        let fixed_data_fields: Vec<(&str, &DataType)> = fixed_schema
+            .fields()
+            .iter()
+            .filter(|f| !f.name().starts_with("_vector_") && f.name() != "date")
+            .map(|f| (f.name().as_str(), f.data_type()))
+            .collect();
+
+        for (field_name, old_arrow_type) in &fixed_data_fields {
+            match incoming_meta.get(*field_name) {
+                Some(mysql_type) => {
+                    let expected = self.type_converter.mysql_to_arrow(mysql_type);
+                    if old_arrow_type != &&expected {
+                        warn!(
+                            "Schema type mismatch for column '{}': fixed={:?}, incoming_mysql='{}'->{:?}. Blocking schema reset.",
+                            field_name, old_arrow_type, mysql_type, expected
+                        );
+                        return EvolutionResult::Blocked;
+                    }
+                }
+                None => {
+                    warn!(
+                        "Schema column '{}' exists in fixed schema but missing from incoming _schema_metadata. Blocking schema reset.",
+                        field_name
+                    );
+                    return EvolutionResult::Blocked;
+                }
+            }
+        }
+
+        if incoming_meta.len() > fixed_data_fields.len() {
+            EvolutionResult::Compatible {
+                incoming_count: incoming_meta.len(),
+                fixed_count: fixed_data_fields.len(),
+            }
+        } else {
+            EvolutionResult::Unchanged
+        }
+    }
+
     /// Get cached partition_by for a table
     pub fn get_partition_by(&self, table_name: &str) -> Option<&Vec<String>> {
         self.cached_schemas
             .get(table_name)
             .and_then(|metadata| metadata.partition_by.as_ref())
+    }
+
+    /// Reset all cached schema state for a table so the next batch rebuilds from scratch.
+    /// Used when incoming events carry new columns not present in the current cached schema.
+    pub fn reset_schema_cache(&mut self, table_name: &str) {
+        self.cached_schemas.remove(table_name);
+        self.cached_arrow_schemas.remove(table_name);
     }
 
     /// Get cached Arrow schema for a table

--- a/tests/system_tables_integration_test.rs
+++ b/tests/system_tables_integration_test.rs
@@ -8,6 +8,68 @@ use std::collections::BTreeMap;
 use std::fs;
 use vector_lib::event::{Event, LogEvent, ObjectMap};
 
+// Helper: build a sqlstatement event with a given schema
+fn make_sqlstatement_event(
+    index: i64,
+    table_name: &str,
+    instance: &str,
+    extra_fields: &[(&str, &str)], // (field_name, mysql_type)
+    extra_values: &[(&str, vector_lib::event::Value)], // (field_name, value)
+) -> Event {
+    let mut log = LogEvent::from(BTreeMap::new());
+
+    // Vector system fields
+    log.insert("_vector_table", table_name);
+    log.insert("_vector_source_table", "CLUSTER_STATEMENTS_SUMMARY");
+    log.insert("_vector_source_schema", "information_schema");
+    log.insert("_vector_instance", instance);
+    log.insert("_vector_timestamp", "2024-06-01T00:00:00Z");
+
+    // Base data fields
+    log.insert("DIGEST", format!("digest_{}", index));
+    log.insert("EXEC_COUNT", index * 100);
+    log.insert("AVG_LATENCY", index as f64 * 1.5);
+    log.insert("INSTANCE", instance);
+
+    // Extra data values (e.g., new column added after schema evolution)
+    for (field, value) in extra_values {
+        log.insert(*field, value.clone());
+    }
+
+    // Build _schema_metadata
+    let mut schema_meta = ObjectMap::new();
+    schema_meta.insert(
+        "_partition_by".into(),
+        vector_lib::event::Value::from("date"),
+    );
+
+    // Base fields
+    for (field, mysql_type) in &[
+        ("DIGEST", "varchar(64)"),
+        ("EXEC_COUNT", "bigint"),
+        ("AVG_LATENCY", "double"),
+        ("INSTANCE", "varchar(64)"),
+    ] {
+        let mut m = ObjectMap::new();
+        m.insert("mysql_type".into(), vector_lib::event::Value::from(*mysql_type));
+        schema_meta.insert((*field).into(), vector_lib::event::Value::Object(m));
+    }
+
+    // Extra schema fields
+    for (field, mysql_type) in extra_fields {
+        let mut m = ObjectMap::new();
+        m.insert("mysql_type".into(), vector_lib::event::Value::from(*mysql_type));
+        schema_meta.insert((*field).into(), vector_lib::event::Value::Object(m));
+    }
+
+    log.insert(
+        "_schema_metadata",
+        vector_lib::event::Value::Object(schema_meta),
+    );
+
+    Event::Log(log)
+}
+
 // Import DeltaLake writer components
 use vector_extensions::sinks::deltalake::{DeltaLakeWriter, DeltaTableConfig, WriteConfig};
 
@@ -519,3 +581,449 @@ async fn test_multiple_tables_to_deltalake() {
     // Clean up
     let _ = fs::remove_dir_all(&base_path);
 }
+
+/// Test that sqlstatement events with an evolved schema (new column added) can be written
+/// to the same Delta table, and that old data files remain valid alongside new ones.
+///
+/// Scenario:
+///   Batch 1 (old schema): DIGEST, EXEC_COUNT, AVG_LATENCY, INSTANCE
+///   Batch 2 (new schema): same columns + PLAN_DIGEST (new column added)
+///
+/// Expected:
+///   - Both batches write successfully (SchemaMode::Merge handles the evolution)
+///   - Delta transaction log records at least 2 versions
+///   - The merged schema in the log contains PLAN_DIGEST
+///   - Old parquet files (batch 1) do NOT contain PLAN_DIGEST — that is fine;
+///     Delta Lake treats missing columns as null when reading the full table
+#[tokio::test]
+async fn test_sqlstatement_schema_evolution_add_column() {
+    use vector_extensions::sinks::deltalake::{DeltaLakeWriter, DeltaTableConfig, WriteConfig};
+
+    let temp_dir = std::env::temp_dir();
+    let test_id = format!(
+        "sqlstmt_schema_evo_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let table_path = temp_dir.join(test_id);
+    fs::create_dir_all(&table_path).expect("Failed to create table directory");
+    println!("Test table path: {:?}", table_path);
+
+    let table_name = "hist_cluster_statements_summary";
+    let write_config = WriteConfig {
+        batch_size: 1000,
+        timeout_secs: 30,
+    };
+
+    // -----------------------------------------------------------------------
+    // Batch 1: write 3 events with the original schema (no PLAN_DIGEST)
+    // -----------------------------------------------------------------------
+    let batch1: Vec<Event> = (0..3)
+        .map(|i| {
+            make_sqlstatement_event(
+                i,
+                table_name,
+                &format!("tidb-{}", i),
+                &[], // no extra schema fields
+                &[], // no extra values
+            )
+        })
+        .collect();
+
+    let mut writer1 = DeltaLakeWriter::new(
+        table_path.clone(),
+        DeltaTableConfig {
+            name: table_name.to_string(),
+            schema_evolution: Some(true),
+        },
+        write_config.clone(),
+        None,
+    );
+
+    writer1
+        .write_events(batch1)
+        .await
+        .expect("Batch 1 (old schema) write failed");
+
+    println!("Batch 1 written with old schema (no PLAN_DIGEST)");
+
+    // Verify table was created
+    let delta_log_path = table_path.join("_delta_log");
+    assert!(
+        delta_log_path.exists(),
+        "_delta_log must exist after batch 1"
+    );
+
+    let log_files_after_batch1: Vec<_> = fs::read_dir(&delta_log_path)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
+        .collect();
+    println!(
+        "Transaction log files after batch 1: {}",
+        log_files_after_batch1.len()
+    );
+    assert!(
+        !log_files_after_batch1.is_empty(),
+        "Should have transaction log after batch 1"
+    );
+
+    // Verify old schema in log does NOT mention PLAN_DIGEST
+    let plan_digest_in_batch1 = log_files_after_batch1.iter().any(|e| {
+        fs::read_to_string(e.path())
+            .unwrap_or_default()
+            .contains("PLAN_DIGEST")
+    });
+    assert!(
+        !plan_digest_in_batch1,
+        "Batch 1 schema should not contain PLAN_DIGEST yet"
+    );
+
+    // -----------------------------------------------------------------------
+    // Batch 2: new writer to the same table, schema now includes PLAN_DIGEST
+    //
+    // Using a fresh DeltaLakeWriter simulates what happens when the process
+    // restarts and the schema has been extended (e.g., TiDB added a column
+    // to CLUSTER_STATEMENTS_SUMMARY).
+    // -----------------------------------------------------------------------
+    let batch2: Vec<Event> = (3..6)
+        .map(|i| {
+            make_sqlstatement_event(
+                i,
+                table_name,
+                &format!("tidb-{}", i),
+                // New column in schema metadata
+                &[("PLAN_DIGEST", "varchar(64)")],
+                // New column value
+                &[(
+                    "PLAN_DIGEST",
+                    vector_lib::event::Value::from(format!("plan_{}", i)),
+                )],
+            )
+        })
+        .collect();
+
+    let mut writer2 = DeltaLakeWriter::new(
+        table_path.clone(),
+        DeltaTableConfig {
+            name: table_name.to_string(),
+            schema_evolution: Some(true),
+        },
+        write_config,
+        None,
+    );
+
+    writer2
+        .write_events(batch2)
+        .await
+        .expect("Batch 2 (new schema with PLAN_DIGEST) write failed");
+
+    println!("Batch 2 written with evolved schema (PLAN_DIGEST added)");
+
+    // -----------------------------------------------------------------------
+    // Assertions: verify schema evolution is reflected in the transaction log
+    // -----------------------------------------------------------------------
+    let log_files_after_batch2: Vec<_> = fs::read_dir(&delta_log_path)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
+        .collect();
+
+    println!(
+        "Transaction log files after batch 2: {}",
+        log_files_after_batch2.len()
+    );
+
+    // After a schema-evolving write, Delta Lake records a new version
+    assert!(
+        log_files_after_batch2.len() > log_files_after_batch1.len(),
+        "Expected more transaction log versions after schema evolution write. \
+         Before: {}, after: {}",
+        log_files_after_batch1.len(),
+        log_files_after_batch2.len()
+    );
+
+    // The new transaction log entry must reference PLAN_DIGEST
+    let plan_digest_in_batch2 = log_files_after_batch2.iter().any(|e| {
+        fs::read_to_string(e.path())
+            .unwrap_or_default()
+            .contains("PLAN_DIGEST")
+    });
+    assert!(
+        plan_digest_in_batch2,
+        "Transaction log after batch 2 must mention PLAN_DIGEST (schema was evolved)"
+    );
+
+    // -----------------------------------------------------------------------
+    // Collect all parquet files to confirm both batches produced data files
+    // -----------------------------------------------------------------------
+    fn collect_parquet_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut result = Vec::new();
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() && !path.to_string_lossy().contains("_delta_log") {
+                    result.extend(collect_parquet_files(&path));
+                } else if path.extension().map(|x| x == "parquet").unwrap_or(false) {
+                    result.push(path);
+                }
+            }
+        }
+        result
+    }
+
+    let parquet_files = collect_parquet_files(&table_path);
+    println!("Total parquet files: {}", parquet_files.len());
+    assert!(
+        parquet_files.len() >= 2,
+        "Expected at least 2 parquet files (one per batch), found {}",
+        parquet_files.len()
+    );
+
+    for f in &parquet_files {
+        let size = fs::metadata(f).unwrap().len();
+        assert!(size > 0, "Parquet file {:?} must not be empty", f);
+        println!("  {:?}  ({} bytes)", f, size);
+    }
+
+    // -----------------------------------------------------------------------
+    // DuckDB query: read the evolved table and verify null-fill for old rows
+    //
+    // DuckDB's delta extension uses the merged schema from the Delta log.
+    // Old parquet files don't have PLAN_DIGEST, so DuckDB fills those rows
+    // with NULL automatically — this is the "old data valid against new schema"
+    // guarantee we want to verify.
+    // -----------------------------------------------------------------------
+    {
+        use duckdb::Connection;
+
+        let conn = Connection::open_in_memory().expect("Failed to open DuckDB connection");
+
+        // Load delta extension
+        let load_result = conn
+            .execute("INSTALL delta;", [])
+            .and_then(|_| conn.execute("LOAD delta;", []));
+
+        if let Err(e) = load_result {
+            println!(
+                "Skipping DuckDB delta_scan verification (delta extension unavailable): {}",
+                e
+            );
+        } else {
+            let table_uri = format!("file://{}", table_path.to_string_lossy());
+
+            // Total row count: both batches = 6 rows
+            let total: i64 = conn
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM delta_scan('{}')", table_uri),
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("DuckDB COUNT query failed");
+            println!("DuckDB: total rows = {}", total);
+            assert_eq!(total, 6, "Expected 6 rows total (3 old + 3 new)");
+
+            // Rows where PLAN_DIGEST IS NULL => batch 1 (old rows)
+            let null_count: i64 = conn
+                .query_row(
+                    &format!(
+                        "SELECT COUNT(*) FROM delta_scan('{}') WHERE PLAN_DIGEST IS NULL",
+                        table_uri
+                    ),
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("DuckDB NULL count query failed");
+            println!("DuckDB: rows with PLAN_DIGEST IS NULL (old batch) = {}", null_count);
+            assert_eq!(
+                null_count, 3,
+                "Old 3 rows must have PLAN_DIGEST=NULL after schema merge"
+            );
+
+            // Rows where PLAN_DIGEST IS NOT NULL => batch 2 (new rows)
+            let non_null_count: i64 = conn
+                .query_row(
+                    &format!(
+                        "SELECT COUNT(*) FROM delta_scan('{}') WHERE PLAN_DIGEST IS NOT NULL",
+                        table_uri
+                    ),
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("DuckDB NOT NULL count query failed");
+            println!(
+                "DuckDB: rows with PLAN_DIGEST NOT NULL (new batch) = {}",
+                non_null_count
+            );
+            assert_eq!(
+                non_null_count, 3,
+                "New 3 rows must have PLAN_DIGEST populated"
+            );
+
+            println!("DuckDB delta_scan verification passed!");
+            println!("  Total rows: 6 (old 3 + new 3)");
+            println!("  Old rows: PLAN_DIGEST=NULL (null-filled by DuckDB for old parquet)");
+            println!("  New rows: PLAN_DIGEST='plan_N' (written in batch 2)");
+        }
+    }
+
+    println!("Schema evolution test passed!");
+    println!("  Batch 1 (old schema, no PLAN_DIGEST): OK");
+    println!("  Batch 2 (new schema, PLAN_DIGEST added): OK");
+    println!("  Delta log records schema change: OK");
+    println!("  Both parquet files valid: OK");
+
+    // Clean up
+    let _ = fs::remove_dir_all(&table_path);
+}
+
+/// Regression test: same writer, new column added mid-run.
+///
+/// This test intentionally reproduces the bug where `fixed_arrow_schema` is locked
+/// after the first write. With the current implementation:
+///   - Batch 1 is written with old schema (no PLAN_DIGEST) — succeeds
+///   - Batch 2 arrives on the SAME writer with new schema (+PLAN_DIGEST)
+///   - Because fixed_arrow_schema is already set, PLAN_DIGEST is dropped silently
+///   - DuckDB delta_scan shows PLAN_DIGEST column is absent from the table schema
+///
+/// When the underlying bug is fixed (fixed_arrow_schema detects new columns and
+/// resets), this test should be updated to assert non-null counts instead.
+#[tokio::test]
+async fn test_sqlstatement_same_writer_new_column_not_visible() {
+    use duckdb::Connection;
+    use vector_extensions::sinks::deltalake::{DeltaLakeWriter, DeltaTableConfig, WriteConfig};
+
+    let temp_dir = std::env::temp_dir();
+    let test_id = format!(
+        "sqlstmt_same_writer_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let table_path = temp_dir.join(test_id);
+    std::fs::create_dir_all(&table_path).expect("Failed to create table directory");
+
+    let table_name = "hist_cluster_statements_summary";
+    let write_config = WriteConfig {
+        batch_size: 1000,
+        timeout_secs: 30,
+    };
+
+    // Single long-running writer — simulates production process that stays up
+    let mut writer = DeltaLakeWriter::new(
+        table_path.clone(),
+        DeltaTableConfig {
+            name: table_name.to_string(),
+            schema_evolution: Some(true),
+        },
+        write_config,
+        None,
+    );
+
+    // Batch 1: old schema (no PLAN_DIGEST)
+    let batch1: Vec<Event> = (0..3)
+        .map(|i| {
+            make_sqlstatement_event(
+                i,
+                table_name,
+                &format!("tidb-{}", i),
+                &[],
+                &[],
+            )
+        })
+        .collect();
+    writer
+        .write_events(batch1)
+        .await
+        .expect("Batch 1 write failed");
+
+    // Batch 2: new schema with PLAN_DIGEST — same writer, no restart
+    let batch2: Vec<Event> = (3..6)
+        .map(|i| {
+            make_sqlstatement_event(
+                i,
+                table_name,
+                &format!("tidb-{}", i),
+                &[("PLAN_DIGEST", "varchar(64)")],
+                &[(
+                    "PLAN_DIGEST",
+                    vector_lib::event::Value::from(format!("plan_{}", i)),
+                )],
+            )
+        })
+        .collect();
+    writer
+        .write_events(batch2)
+        .await
+        .expect("Batch 2 write failed");
+
+    // DuckDB query to check whether PLAN_DIGEST is visible
+    let conn = Connection::open_in_memory().expect("Failed to open DuckDB connection");
+    let load_result = conn
+        .execute("INSTALL delta;", [])
+        .and_then(|_| conn.execute("LOAD delta;", []));
+
+    if let Err(e) = load_result {
+        println!("Skipping DuckDB check (delta extension unavailable): {}", e);
+        let _ = std::fs::remove_dir_all(&table_path);
+        return;
+    }
+
+    let table_uri = format!("file://{}", table_path.to_string_lossy());
+
+    // Check if PLAN_DIGEST column exists in the Delta schema at all
+    // by trying to query it; if the column is missing, the query will error.
+    let schema_has_plan_digest: bool = conn
+        .execute(
+            &format!(
+                "SELECT PLAN_DIGEST FROM delta_scan('{}') LIMIT 1",
+                table_uri
+            ),
+            [],
+        )
+        .is_ok();
+
+    // The same writer must pick up new columns from _schema_metadata and write them
+    // to Delta Lake. After schema evolution, PLAN_DIGEST should be in the table.
+    assert!(
+        schema_has_plan_digest,
+        "same-writer schema evolution failed: PLAN_DIGEST not found in Delta table schema. \
+         Root cause: fixed_arrow_schema is locked after first write and never reset when \
+         new columns appear in _schema_metadata."
+    );
+
+    // Also verify null-fill: old rows have PLAN_DIGEST=NULL, new rows have it populated
+    let null_count: i64 = conn
+        .query_row(
+            &format!(
+                "SELECT COUNT(*) FROM delta_scan('{}') WHERE PLAN_DIGEST IS NULL",
+                table_uri
+            ),
+            [],
+            |row| row.get(0),
+        )
+        .expect("DuckDB NULL count query failed");
+    assert_eq!(null_count, 3, "Old 3 rows must have PLAN_DIGEST=NULL");
+
+    let non_null_count: i64 = conn
+        .query_row(
+            &format!(
+                "SELECT COUNT(*) FROM delta_scan('{}') WHERE PLAN_DIGEST IS NOT NULL",
+                table_uri
+            ),
+            [],
+            |row| row.get(0),
+        )
+        .expect("DuckDB NOT NULL count query failed");
+    assert_eq!(non_null_count, 3, "New 3 rows must have PLAN_DIGEST populated");
+
+    println!("Same-writer schema evolution test passed!");
+    println!("  Old rows: PLAN_DIGEST=NULL");
+    println!("  New rows: PLAN_DIGEST='plan_N'");
+
+    let _ = std::fs::remove_dir_all(&table_path);
+}
+


### PR DESCRIPTION
…writer runs

Root cause: fixed_arrow_schema was locked after the first write_events() call, silently dropping new columns from subsequent batches on the same writer instance.

Fix:
- Add EvolutionResult enum and check_schema_evolution() to SchemaManager; it compares incoming _schema_metadata against the fixed Arrow schema and blocks on column drops or type changes, allowing only additive evolutions
- Reset fixed_arrow_schema + schema cache when new compatible columns are detected, letting SchemaMode::Merge on the next write propagate them into the Delta log
- Add regression tests: two-writer (restart simulation) and same-writer scenarios, both verified via DuckDB delta_scan null-fill assertions

Cleanup (from code review):
- Move the compatibility-check logic into SchemaManager (was leaking into DeltaLakeWriter)
- Use HashMap instead of BTreeMap for incoming_meta (O(1) lookups, hot path)
- Remove unused imports: BTreeMap, DataType, warn, Value as EventValue from mod.rs
- Drop unreachable "fewer columns" warning branch (loop already catches it as Blocked)
- Use early-exit any() in tests instead of concatenating all log files into one String