### PR TITLE
fix: filter stale time windows from CLUSTER_STATEMENTS_SUMMARY in multi-node clusters

### DIFF
--- a/src/sources/system_tables/collectors/coprocessor_collector.rs
+++ b/src/sources/system_tables/collectors/coprocessor_collector.rs
@@ -1998,6 +1998,28 @@ impl DataCollector for CoprocessorCollector {
             }
         };
 
+        // Apply post-filter if where_clause is configured.
+        // For STATEMENTS_SUMMARY tables, auto-apply 1 hour filter if no where_clause is set.
+        let where_clause = table.where_clause.as_deref().or_else(|| {
+            if table.source_table.contains("STATEMENTS_SUMMARY") {
+                Some("SUMMARY_END_TIME >= DATE_SUB(NOW(), INTERVAL 1 HOUR)")
+            } else {
+                None
+            }
+        });
+
+        let data = if let Some(clause) = where_clause {
+            let before = data.len();
+            let filtered = apply_time_filter(data, clause);
+            info!(
+                "Post-filter applied for table {}: where_clause='{}', {} -> {} rows",
+                table.source_table, clause, before, filtered.len()
+            );
+            filtered
+        } else {
+            data
+        };
+
         let duration = start_time.elapsed();
         let row_count = data.len();
 
@@ -2059,4 +2081,74 @@ impl DataCollector for CoprocessorCollector {
         // or check the gRPC connection status
         Ok(())
     }
+}
+
+/// Apply time-based post-filter to collected rows based on a where_clause string.
+///
+/// Supports the pattern: `COLUMN >= DATE_SUB(NOW(), INTERVAL N HOUR|MINUTE)`
+/// Time field values are expected as `Value::String("YYYY-MM-DD HH:MM:SS")`.
+/// If the clause cannot be parsed, all rows are returned unchanged.
+pub fn apply_time_filter(
+    rows: Vec<std::collections::HashMap<String, serde_json::Value>>,
+    where_clause: &str,
+) -> Vec<std::collections::HashMap<String, serde_json::Value>> {
+    // Parse: COLUMN >= DATE_SUB(NOW(), INTERVAL N HOUR|MINUTE) (case-insensitive)
+    let upper = where_clause.to_uppercase();
+    let Some((column, rest)) = upper.split_once(">=") else {
+        return rows;
+    };
+    let column = column.trim().to_string();
+    let rest = rest.trim();
+
+    // rest should look like: DATE_SUB(NOW(), INTERVAL N HOUR|MINUTE)
+    let Some(inner) = rest
+        .strip_prefix("DATE_SUB(NOW(),")
+        .or_else(|| rest.strip_prefix("DATE_SUB( NOW() ,"))
+        .or_else(|| rest.strip_prefix("DATE_SUB(NOW() ,"))
+        .or_else(|| rest.strip_prefix("DATE_SUB( NOW(),"))
+    else {
+        return rows;
+    };
+    let inner = inner.trim().trim_end_matches(')').trim();
+    // inner: INTERVAL N HOUR|MINUTE
+    let Some(interval_body) = inner.strip_prefix("INTERVAL") else {
+        return rows;
+    };
+    let parts: Vec<&str> = interval_body.split_whitespace().collect();
+    if parts.len() < 2 {
+        return rows;
+    }
+    let Ok(n) = parts[0].parse::<i64>() else {
+        return rows;
+    };
+    let cutoff = chrono::Utc::now()
+        - match parts[1] {
+            "HOUR" => chrono::Duration::hours(n),
+            "MINUTE" => chrono::Duration::minutes(n),
+            _ => return rows,
+        };
+    let cutoff_naive = cutoff.naive_utc();
+
+    // Use the original-case column name from the raw where_clause
+    let raw_upper = where_clause.to_uppercase();
+    let col_raw = where_clause[..raw_upper.find(">=").unwrap_or(0)]
+        .trim()
+        .to_string();
+
+    rows.into_iter()
+        .filter(|row| {
+            let Some(val) = row.get(&col_raw) else {
+                return true;
+            };
+            let Some(s) = val.as_str() else {
+                return true;
+            };
+            let Ok(row_time) =
+                chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
+            else {
+                return true;
+            };
+            row_time >= cutoff_naive
+        })
+        .collect()
 }

--- a/src/sources/system_tables/collectors/coprocessor_collector.rs
+++ b/src/sources/system_tables/collectors/coprocessor_collector.rs
@@ -1998,22 +1998,33 @@ impl DataCollector for CoprocessorCollector {
             }
         };
 
-        // Apply post-filter if where_clause is configured.
-        // For STATEMENTS_SUMMARY tables, auto-apply 1 hour filter if no where_clause is set.
-        let where_clause = table.where_clause.as_deref().or_else(|| {
-            if table.source_table.contains("STATEMENTS_SUMMARY") {
-                Some("SUMMARY_END_TIME >= DATE_SUB(NOW(), INTERVAL 1 HOUR)")
-            } else {
-                None
-            }
-        });
-
-        let data = if let Some(clause) = where_clause {
+        // Apply a configured time-based post-filter first. Coprocessor requests are
+        // DAG requests, so the clause cannot be pushed down as SQL.
+        let data = if let Some(clause) = table.where_clause.as_deref() {
             let before = data.len();
-            let filtered = apply_time_filter(data, clause);
+            let filtered = apply_time_filter(data, clause, timestamp);
             info!(
                 "Post-filter applied for table {}: where_clause='{}', {} -> {} rows",
                 table.source_table, clause, before, filtered.len()
+            );
+            filtered
+        } else {
+            data
+        };
+
+        // STATEMENTS_SUMMARY is lazily rotated by TiDB. An inactive TiDB can
+        // therefore keep returning its last closed window on every collection.
+        // Keep only rows whose window was still open when this collection began.
+        // This is based solely on the window timestamp, so it also covers the
+        // Others row, whose DIGEST and DIGEST_TEXT are NULL.
+        let data = if is_current_statements_summary_table(&table.source_table) {
+            let before = data.len();
+            let filtered = filter_current_statement_summary_rows(data, timestamp);
+            info!(
+                "Current-window filter applied for table {}: {} -> {} rows",
+                table.source_table,
+                before,
+                filtered.len()
             );
             filtered
         } else {
@@ -2086,18 +2097,19 @@ impl DataCollector for CoprocessorCollector {
 /// Apply time-based post-filter to collected rows based on a where_clause string.
 ///
 /// Supports the pattern: `COLUMN >= DATE_SUB(NOW(), INTERVAL N HOUR|MINUTE)`
-/// Time field values are expected as `Value::String("YYYY-MM-DD HH:MM:SS")`.
+/// Time field values can be Unix microseconds from the coprocessor TIMESTAMP
+/// decoder or strings in `YYYY-MM-DD HH:MM:SS`/RFC 3339 format.
 /// If the clause cannot be parsed, all rows are returned unchanged.
-pub fn apply_time_filter(
+fn apply_time_filter(
     rows: Vec<std::collections::HashMap<String, serde_json::Value>>,
     where_clause: &str,
+    now: chrono::DateTime<chrono::Utc>,
 ) -> Vec<std::collections::HashMap<String, serde_json::Value>> {
     // Parse: COLUMN >= DATE_SUB(NOW(), INTERVAL N HOUR|MINUTE) (case-insensitive)
     let upper = where_clause.to_uppercase();
-    let Some((column, rest)) = upper.split_once(">=") else {
+    let Some((_, rest)) = upper.split_once(">=") else {
         return rows;
     };
-    let column = column.trim().to_string();
     let rest = rest.trim();
 
     // rest should look like: DATE_SUB(NOW(), INTERVAL N HOUR|MINUTE)
@@ -2121,7 +2133,7 @@ pub fn apply_time_filter(
     let Ok(n) = parts[0].parse::<i64>() else {
         return rows;
     };
-    let cutoff = chrono::Utc::now()
+    let cutoff = now
         - match parts[1] {
             "HOUR" => chrono::Duration::hours(n),
             "MINUTE" => chrono::Duration::minutes(n),
@@ -2140,15 +2152,50 @@ pub fn apply_time_filter(
             let Some(val) = row.get(&col_raw) else {
                 return true;
             };
-            let Some(s) = val.as_str() else {
-                return true;
-            };
-            let Ok(row_time) =
-                chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
-            else {
+            let Some(row_time) = parse_coprocessor_time(val) else {
                 return true;
             };
             row_time >= cutoff_naive
         })
         .collect()
+}
+
+fn is_current_statements_summary_table(table_name: &str) -> bool {
+    table_name.eq_ignore_ascii_case("STATEMENTS_SUMMARY")
+        || table_name.eq_ignore_ascii_case("CLUSTER_STATEMENTS_SUMMARY")
+}
+
+/// Keep only statement-summary rows whose interval was still open when the
+/// collection began. Closed rows are immutable and would otherwise be emitted
+/// again on every poll from an inactive TiDB node.
+pub fn filter_current_statement_summary_rows(
+    rows: Vec<std::collections::HashMap<String, serde_json::Value>>,
+    collected_at: chrono::DateTime<chrono::Utc>,
+) -> Vec<std::collections::HashMap<String, serde_json::Value>> {
+    let collected_at = collected_at.naive_utc();
+    rows.into_iter()
+        .filter(|row| {
+            row.get("SUMMARY_END_TIME")
+                .and_then(parse_coprocessor_time)
+                // Preserve rows with an unknown representation instead of
+                // silently losing data if TiDB changes the encoding.
+                .is_none_or(|end_time| end_time > collected_at)
+        })
+        .collect()
+}
+
+fn parse_coprocessor_time(value: &serde_json::Value) -> Option<chrono::NaiveDateTime> {
+    if let Some(micros) = value.as_i64() {
+        return chrono::DateTime::<chrono::Utc>::from_timestamp_micros(micros)
+            .map(|time| time.naive_utc());
+    }
+
+    let value = value.as_str()?;
+    chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
+        .ok()
+        .or_else(|| {
+            chrono::DateTime::parse_from_rfc3339(value)
+                .ok()
+                .map(|time| time.naive_utc())
+        })
 }

--- a/tests/system_tables_integration_test.rs
+++ b/tests/system_tables_integration_test.rs
@@ -1028,79 +1028,52 @@ async fn test_sqlstatement_same_writer_new_column_not_visible() {
 }
 
 #[tokio::test]
-async fn test_statements_summary_multi_node_filter() {
-    use chrono::{Duration, Utc};
+async fn test_statements_summary_multi_node_filter_including_others() {
+    use chrono::{Duration, TimeZone, Utc};
     use serde_json::json;
     use std::collections::HashMap;
-    use vector_extensions::sources::system_tables::collectors::coprocessor_collector::apply_time_filter;
+    use vector_extensions::sources::system_tables::collectors::coprocessor_collector::filter_current_statement_summary_rows;
 
-    // Simulate 3 TiDB nodes with different last-active times
-    // Node 1: inactive for 3 days (very old window)
-    // Node 2: inactive for 7 hours (old window)
-    // Node 3: active recently (current window, within 30 minutes)
-
-    let now = Utc::now().naive_utc();
-    let node1_end = (now - Duration::days(3)).format("%Y-%m-%d %H:%M:%S").to_string();
-    let node1_begin = (now - Duration::days(3) - Duration::minutes(30)).format("%Y-%m-%d %H:%M:%S").to_string();
-
-    let node2_end = (now - Duration::hours(7)).format("%Y-%m-%d %H:%M:%S").to_string();
-    let node2_begin = (now - Duration::hours(7) - Duration::minutes(30)).format("%Y-%m-%d %H:%M:%S").to_string();
-
-    let node3_end = (now - Duration::minutes(10)).format("%Y-%m-%d %H:%M:%S").to_string();
-    let node3_begin = (now - Duration::minutes(40)).format("%Y-%m-%d %H:%M:%S").to_string();
+    let collected_at = Utc.with_ymd_and_hms(2026, 4, 2, 16, 29, 40).unwrap();
+    let closed_begin = collected_at - Duration::minutes(59) - Duration::seconds(40);
+    let closed_end = collected_at - Duration::minutes(29) - Duration::seconds(40);
+    let current_begin = collected_at - Duration::minutes(29) - Duration::seconds(40);
+    let current_end = collected_at + Duration::seconds(20);
 
     let mut rows = Vec::new();
 
-    // Node 1 rows (very old, should be filtered out)
-    for i in 0..4 {
+    for (digest, begin, end, encode_as_string) in [
+        (Some("closed_query"), closed_begin, closed_end, true),
+        (None, closed_begin, closed_end, false),
+        (Some("current_query"), current_begin, current_end, false),
+        (None, current_begin, current_end, true),
+    ] {
         let mut row = HashMap::new();
-        row.insert("SUMMARY_BEGIN_TIME".to_string(), json!(node1_begin));
-        row.insert("SUMMARY_END_TIME".to_string(), json!(node1_end));
-        row.insert("DIGEST_TEXT".to_string(), json!(format!("old_query_{}", i)));
+        let (begin, end) = if encode_as_string {
+            (
+                json!(begin.format("%Y-%m-%d %H:%M:%S").to_string()),
+                json!(end.format("%Y-%m-%d %H:%M:%S").to_string()),
+            )
+        } else {
+            // Coprocessor TIMESTAMP decoding normally produces Unix microseconds.
+            (json!(begin.timestamp_micros()), json!(end.timestamp_micros()))
+        };
+        row.insert("SUMMARY_BEGIN_TIME".to_string(), begin);
+        row.insert("SUMMARY_END_TIME".to_string(), end);
+        row.insert("DIGEST".to_string(), json!(digest));
+        row.insert("DIGEST_TEXT".to_string(), json!(digest));
         row.insert("EXEC_COUNT".to_string(), json!(1));
         rows.push(row);
     }
 
-    // Node 2 rows (old, should be filtered out)
-    for i in 0..2 {
-        let mut row = HashMap::new();
-        row.insert("SUMMARY_BEGIN_TIME".to_string(), json!(node2_begin));
-        row.insert("SUMMARY_END_TIME".to_string(), json!(node2_end));
-        row.insert("DIGEST_TEXT".to_string(), json!(format!("stale_query_{}", i)));
-        row.insert("EXEC_COUNT".to_string(), json!(1));
-        rows.push(row);
-    }
+    let filtered = filter_current_statement_summary_rows(rows, collected_at);
 
-    // Node 3 rows (recent, should be kept)
-    for i in 0..4 {
-        let mut row = HashMap::new();
-        row.insert("SUMMARY_BEGIN_TIME".to_string(), json!(node3_begin));
-        row.insert("SUMMARY_END_TIME".to_string(), json!(node3_end));
-        row.insert("DIGEST_TEXT".to_string(), json!(format!("recent_query_{}", i)));
-        row.insert("EXEC_COUNT".to_string(), json!(1));
-        rows.push(row);
-    }
-
-    assert_eq!(rows.len(), 10, "Should have 10 total rows before filtering");
-
-    // Apply the auto-filter (1 hour window)
-    let where_clause = "SUMMARY_END_TIME >= DATE_SUB(NOW(), INTERVAL 1 HOUR)";
-    let filtered = apply_time_filter(rows, where_clause);
-
-    // Only Node 3's recent rows should remain
-    assert_eq!(filtered.len(), 4, "Should keep only the 4 recent rows from active node");
-
-    for row in &filtered {
-        let digest = row.get("DIGEST_TEXT").unwrap().as_str().unwrap();
-        assert!(
-            digest.starts_with("recent_query_"),
-            "Filtered rows should only contain recent queries, got: {}",
-            digest
-        );
-    }
-
-    println!("Multi-node filter test passed!");
-    println!("  - Node 1 (3 days old): 4 rows filtered out");
-    println!("  - Node 2 (7 hours old): 2 rows filtered out");
-    println!("  - Node 3 (recent): 4 rows kept");
+    assert_eq!(filtered.len(), 2);
+    assert!(filtered
+        .iter()
+        .any(|row| row["DIGEST"] == json!("current_query")));
+    assert!(filtered.iter().any(|row| row["DIGEST"].is_null()));
+    assert!(filtered
+        .iter()
+        .all(|row| row["DIGEST"] != json!("closed_query")));
 }

--- a/tests/system_tables_integration_test.rs
+++ b/tests/system_tables_integration_test.rs
@@ -1027,3 +1027,80 @@ async fn test_sqlstatement_same_writer_new_column_not_visible() {
     let _ = std::fs::remove_dir_all(&table_path);
 }
 
+#[tokio::test]
+async fn test_statements_summary_multi_node_filter() {
+    use chrono::{Duration, Utc};
+    use serde_json::json;
+    use std::collections::HashMap;
+    use vector_extensions::sources::system_tables::collectors::coprocessor_collector::apply_time_filter;
+
+    // Simulate 3 TiDB nodes with different last-active times
+    // Node 1: inactive for 3 days (very old window)
+    // Node 2: inactive for 7 hours (old window)
+    // Node 3: active recently (current window, within 30 minutes)
+
+    let now = Utc::now().naive_utc();
+    let node1_end = (now - Duration::days(3)).format("%Y-%m-%d %H:%M:%S").to_string();
+    let node1_begin = (now - Duration::days(3) - Duration::minutes(30)).format("%Y-%m-%d %H:%M:%S").to_string();
+
+    let node2_end = (now - Duration::hours(7)).format("%Y-%m-%d %H:%M:%S").to_string();
+    let node2_begin = (now - Duration::hours(7) - Duration::minutes(30)).format("%Y-%m-%d %H:%M:%S").to_string();
+
+    let node3_end = (now - Duration::minutes(10)).format("%Y-%m-%d %H:%M:%S").to_string();
+    let node3_begin = (now - Duration::minutes(40)).format("%Y-%m-%d %H:%M:%S").to_string();
+
+    let mut rows = Vec::new();
+
+    // Node 1 rows (very old, should be filtered out)
+    for i in 0..4 {
+        let mut row = HashMap::new();
+        row.insert("SUMMARY_BEGIN_TIME".to_string(), json!(node1_begin));
+        row.insert("SUMMARY_END_TIME".to_string(), json!(node1_end));
+        row.insert("DIGEST_TEXT".to_string(), json!(format!("old_query_{}", i)));
+        row.insert("EXEC_COUNT".to_string(), json!(1));
+        rows.push(row);
+    }
+
+    // Node 2 rows (old, should be filtered out)
+    for i in 0..2 {
+        let mut row = HashMap::new();
+        row.insert("SUMMARY_BEGIN_TIME".to_string(), json!(node2_begin));
+        row.insert("SUMMARY_END_TIME".to_string(), json!(node2_end));
+        row.insert("DIGEST_TEXT".to_string(), json!(format!("stale_query_{}", i)));
+        row.insert("EXEC_COUNT".to_string(), json!(1));
+        rows.push(row);
+    }
+
+    // Node 3 rows (recent, should be kept)
+    for i in 0..4 {
+        let mut row = HashMap::new();
+        row.insert("SUMMARY_BEGIN_TIME".to_string(), json!(node3_begin));
+        row.insert("SUMMARY_END_TIME".to_string(), json!(node3_end));
+        row.insert("DIGEST_TEXT".to_string(), json!(format!("recent_query_{}", i)));
+        row.insert("EXEC_COUNT".to_string(), json!(1));
+        rows.push(row);
+    }
+
+    assert_eq!(rows.len(), 10, "Should have 10 total rows before filtering");
+
+    // Apply the auto-filter (1 hour window)
+    let where_clause = "SUMMARY_END_TIME >= DATE_SUB(NOW(), INTERVAL 1 HOUR)";
+    let filtered = apply_time_filter(rows, where_clause);
+
+    // Only Node 3's recent rows should remain
+    assert_eq!(filtered.len(), 4, "Should keep only the 4 recent rows from active node");
+
+    for row in &filtered {
+        let digest = row.get("DIGEST_TEXT").unwrap().as_str().unwrap();
+        assert!(
+            digest.starts_with("recent_query_"),
+            "Filtered rows should only contain recent queries, got: {}",
+            digest
+        );
+    }
+
+    println!("Multi-node filter test passed!");
+    println!("  - Node 1 (3 days old): 4 rows filtered out");
+    println!("  - Node 2 (7 hours old): 2 rows filtered out");
+    println!("  - Node 3 (recent): 4 rows kept");
+}


### PR DESCRIPTION
## Problem

In a multi-node TiDB cluster, `CLUSTER_STATEMENTS_SUMMARY` aggregates data from all TiDB nodes. Each node tracks its own `beginTimeForCurInterval`, which is only updated when a SQL statement executes on that node. Inactive nodes never advance their interval, so they always return their last-seen time window — which can be hours or days old.

**Example from production** (3-node cluster, queried at `2026-04-02 16:00`):

```
SELECT INSTANCE, SUMMARY_BEGIN_TIME, SUMMARY_END_TIME, COUNT(*)
FROM INFORMATION_SCHEMA.CLUSTER_STATEMENTS_SUMMARY
GROUP BY INSTANCE, SUMMARY_BEGIN_TIME, SUMMARY_END_TIME;

+------------------+---------------------+---------------------+----------+
| INSTANCE         | SUMMARY_BEGIN_TIME  | SUMMARY_END_TIME    | COUNT(*) |
+------------------+---------------------+---------------------+----------+
| 10.0.1.1:10080   | 2026-03-31 10:30:00 | 2026-03-31 11:00:00 |        4 |  -- 3 days old
| 10.0.1.2:10080   | 2026-04-02 09:00:00 | 2026-04-02 09:30:00 |        2 |  -- 7 hours old
| 10.0.1.3:10080   | 2026-04-02 15:30:00 | 2026-04-02 16:00:00 |        4 |  -- current
+------------------+---------------------+---------------------+----------+
```

The coprocessor collector collects all 10 rows and writes them to Delta Lake. On the next collection cycle (30 min later), the same stale rows from nodes 1 and 2 are collected again — producing duplicate records in the Delta Lake table for the same `SUMMARY_BEGIN_TIME`/`SUMMARY_END_TIME` window.

**Root cause**: `CLUSTER_STATEMENTS_SUMMARY` maps to `GetStmtSummaryCurrentRows()` in TiDB, which returns each node's "current" window based on its own `beginTimeForCurInterval`. There is no cross-node time alignment. Inactive nodes never call `AddStatement()`, so their `beginTimeForCurInterval` is frozen at the last time they saw traffic.

## Fix

Auto-apply a post-filter `SUMMARY_END_TIME >= DATE_SUB(NOW(), INTERVAL 1 HOUR)` in the coprocessor collector for all `STATEMENTS_SUMMARY` tables, without requiring any configuration change. If the user has already configured a `where_clause`, it takes precedence.

The filter is applied in-memory after collection, since the coprocessor collector uses gRPC DAG requests (not SQL) and cannot push WHERE clauses to TiDB.

## Test

Added `test_statements_summary_multi_node_filter`: simulates 10 rows from 3 nodes with windows at 3 days ago, 7 hours ago, and 10 minutes ago. Verifies that only the 4 recent rows are kept after filtering.

## Review follow-up: current-window and `Others` safeguards

The original problem statement, production example, and root-cause analysis above remain unchanged. During code review, the initial one-hour post-filter was found to need the following implementation adjustments:

1. A window that closed less than one hour ago still passes `SUMMARY_END_TIME >= DATE_SUB(NOW(), INTERVAL 1 HOUR)`, so it can be appended again on the next collection cycle.
2. The coprocessor collector normally decodes TiDB `TIMESTAMP` columns as Unix microseconds. The initial filter only parsed strings, so numeric `SUMMARY_END_TIME` values were left unfiltered.
3. Letting a configured `where_clause` replace the safeguard could disable duplicate-window protection.
4. Matching every table name containing `STATEMENTS_SUMMARY` could also affect history tables.

The reviewed implementation therefore keeps only rows from intervals that were still open when collection began:

```text
SUMMARY_END_TIME > collection_started_at
```

This safeguard applies only to the current `STATEMENTS_SUMMARY` and `CLUSTER_STATEMENTS_SUMMARY` tables. It supports both Unix-microsecond and string timestamp representations, and it runs independently after any configured time-based post-filter.

The check depends only on `SUMMARY_END_TIME`, so it also covers the `Others` row even though its `DIGEST` and `DIGEST_TEXT` are NULL. A closed historical `Others` window repeatedly returned by TiDB is filtered before events are sent to the append-only Delta Lake sink.

The regression test was updated to include normal and `Others` rows from both a recently closed window and the current open window, using both timestamp representations. The closed rows are removed and both current rows are retained.

Additional fix commit: `b656614`.
