### PR TITLE
0.49 gcs deltalake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4713,6 +4713,7 @@ dependencies = [
  "deltalake-aws",
  "deltalake-azure",
  "deltalake-core",
+ "deltalake-gcp",
 ]
 
 [[package]]
@@ -4819,6 +4820,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "deltalake-gcp"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df2708856cfa92e8309141fda1ee8d41e174b0868f26e557d0b2ea8d30fb92e"
+dependencies = [
+ "async-trait",
+ "bytes 1.10.1",
+ "deltalake-core",
+ "futures 0.3.31",
+ "object_store 0.12.4",
+ "thiserror 2.0.15",
+ "tokio",
+ "tracing 0.1.41",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ azure_storage_blobs = { version = "0.17.0", default-features = false, features =
 base64 = { version = "0.22.1", default-features = false }
 bytes = { version = "1.10.1", default-features = false, features = ["serde"] }
 chrono = { version = "0.4.41", default-features = false, features = ["clock", "serde"] }
-deltalake = { version = "0.29.3", features = ["datafusion", "s3", "azure"] }
+deltalake = { version = "0.29.3", features = ["datafusion", "s3", "azure", "gcs"] }
 datafusion = { version = "48" }
 duckdb = { version = "1.0", features = ["bundled"] }
 etcd-client = { version = "0.14", features = ["tls-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ default-run = "vector"
 [profile.release]
 codegen-units = 1
 lto = "fat"
+strip = true
+panic = "abort"
+opt-level = "z"
 
 [[bin]]
 name = "vector"

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,20 @@ release-docker: target/aarch64-unknown-linux-gnu/release/vector
 	@scripts/release-docker.sh
 	@echo "Done releasing docker image."
 
+.PHONY: release-docker-alpine
+release-docker-alpine: target/x86_64-unknown-linux-musl/release/vector
+release-docker-alpine: target/aarch64-unknown-linux-musl/release/vector
+	@echo "Releasing Alpine docker image..."
+	@DOCKER_BASE=alpine scripts/release-docker.sh
+	@echo "Done releasing Alpine docker image."
+
+.PHONY: release-docker-minimal
+release-docker-minimal: target/x86_64-unknown-linux-musl/release/vector
+release-docker-minimal: target/aarch64-unknown-linux-musl/release/vector
+	@echo "Releasing minimal scratch docker image..."
+	@DOCKER_BASE=minimal scripts/release-docker.sh
+	@echo "Done releasing minimal scratch docker image."
+
 .PHONY: release-docker-nextgen
 release-docker-nextgen: target/x86_64-unknown-linux-gnu/release/vector-nextgen
 release-docker-nextgen: target/aarch64-unknown-linux-gnu/release/vector-nextgen
@@ -198,6 +212,13 @@ release-docker-nextgen: target/aarch64-unknown-linux-gnu/release/vector-nextgen
 	@echo "Releasing docker image (nextgen mode)..."
 	@NEXTGEN=true scripts/release-docker.sh
 	@echo "Done releasing docker image (nextgen mode)."
+
+.PHONY: release-docker-nextgen-alpine
+release-docker-nextgen-alpine: target/x86_64-unknown-linux-musl/release/vector-nextgen
+release-docker-nextgen-alpine: target/aarch64-unknown-linux-musl/release/vector-nextgen
+	@echo "Releasing Alpine docker image (nextgen mode)..."
+	@NEXTGEN=true DOCKER_BASE=alpine scripts/release-docker.sh
+	@echo "Done releasing Alpine docker image (nextgen mode)."
 
 .PHONY: test-integration
 test-integration:

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,8 +1,28 @@
+# Multi-stage build for smaller final image
+FROM docker.io/debian:13-slim as builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+    systemd \
+    curl \
+    binutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Final stage with minimal runtime dependencies
 FROM docker.io/debian:13-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata systemd curl binutils
+
+# Install only runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+    systemd \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
 
 ARG TARGETARCH
-COPY vector-$TARGETARCH /usr/bin/vector
+COPY --from=builder /usr/bin/vector-$TARGETARCH /usr/bin/vector
 # COPY vector.toml /etc/vector/vector.toml
 
 ENV VECTOR_LOG="info"

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean
 
 ARG TARGETARCH
-COPY --from=builder /usr/bin/vector-$TARGETARCH /usr/bin/vector
+COPY vector-$TARGETARCH /usr/bin/vector
 # COPY vector.toml /etc/vector/vector.toml
 
 ENV VECTOR_LOG="info"

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -43,7 +43,16 @@ REPO="${REPO:-"tidbcloud/vector"}"
 BASE="${DOCKER_BASE:-debian}"
 
 TAG="${TAG:-$REPO:$VERSION-$BASE}"
-DOCKERFILE="scripts/docker/Dockerfile${BASE:+.${BASE}}"
+# Default Debian image uses scripts/docker/Dockerfile (no .debian suffix).
+# Alpine/minimal use scripts/docker/Dockerfile.<base>.
+case "${BASE}" in
+debian)
+	DOCKERFILE="scripts/docker/Dockerfile"
+	;;
+*)
+	DOCKERFILE="scripts/docker/Dockerfile.${BASE}"
+	;;
+esac
 
 #PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
 PLATFORMS="linux/amd64,linux/arm64"

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -40,10 +40,10 @@ cp target/aarch64-unknown-linux-gnu/release/${BINARY_NAME} "$WORK_DIR"/vector-ar
 
 VERSION="${VECTOR_VERSION:-"$(scripts/version.sh)"}"
 REPO="${REPO:-"tidbcloud/vector"}"
-BASE=debian
+BASE="${DOCKER_BASE:-debian}"
 
 TAG="${TAG:-$REPO:$VERSION-$BASE}"
-DOCKERFILE="scripts/docker/Dockerfile"
+DOCKERFILE="scripts/docker/Dockerfile${BASE:+.${BASE}}"
 
 #PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
 PLATFORMS="linux/amd64,linux/arm64"

--- a/src/common/deltalake_writer/delta_ops.rs
+++ b/src/common/deltalake_writer/delta_ops.rs
@@ -46,7 +46,7 @@ impl DeltaOpsManager {
                 *session_token = "***REDACTED***".to_string();
             }
             info!(
-                "Using storage options for S3 authentication: {:?}",
+                "Using storage options: {:?}",
                 redacted_options
             );
             Ok(DeltaOps::try_from_uri_with_storage_options(

--- a/src/common/deltalake_writer/delta_ops.rs
+++ b/src/common/deltalake_writer/delta_ops.rs
@@ -9,6 +9,7 @@ use deltalake::DeltaOps;
 use tracing::{error, info, warn};
 use url::Url;
 
+use super::errors::is_stale_delta_log_error;
 use super::schema::SchemaManager;
 use super::types::TypeConverter;
 
@@ -272,6 +273,24 @@ impl DeltaOpsManager {
                         } else {
                             error!(
                                 "Transaction conflict after {} retries: {}",
+                                MAX_RETRIES, error_str
+                            );
+                            return Err(e.into());
+                        }
+                    }
+                    // Stale log view after external compaction or concurrent writers
+                    else if is_stale_delta_log_error(&error_str) {
+                        if attempt < MAX_RETRIES - 1 {
+                            warn!(
+                                "Stale Delta log detected (attempt {}/{}): {}. Reloading table and retrying...",
+                                attempt + 1,
+                                MAX_RETRIES,
+                                error_str
+                            );
+                            continue;
+                        } else {
+                            error!(
+                                "Stale Delta log after {} retries: {}",
                                 MAX_RETRIES, error_str
                             );
                             return Err(e.into());

--- a/src/common/deltalake_writer/errors.rs
+++ b/src/common/deltalake_writer/errors.rs
@@ -1,0 +1,33 @@
+/// Returns true when a Delta Lake write error likely reflects a stale table log view,
+/// for example after external compaction removed older `_delta_log` JSON files.
+pub fn is_stale_delta_log_error(error_msg: &str) -> bool {
+    error_msg.contains("log segment")
+        || error_msg.contains("Invalid table version")
+        || error_msg.contains("not found")
+        || error_msg.contains("No such file or directory")
+        || error_msg.contains("Kernel error")
+        || error_msg.contains("No table metadata or protocol found in delta log")
+        || error_msg.contains("Expected ordered contiguous commit files")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_stale_delta_log_error;
+
+    #[test]
+    fn detects_missing_delta_log_file() {
+        let msg = "Kernel error: File not found: deltalake/org=1/_delta_log/00000000000000020406.json";
+        assert!(is_stale_delta_log_error(msg));
+    }
+
+    #[test]
+    fn detects_kernel_error_without_file_not_found() {
+        let msg = "Kernel error: No table metadata or protocol found in delta log.";
+        assert!(is_stale_delta_log_error(msg));
+    }
+
+    #[test]
+    fn ignores_unrelated_errors() {
+        assert!(!is_stale_delta_log_error("permission denied"));
+    }
+}

--- a/src/common/deltalake_writer/mod.rs
+++ b/src/common/deltalake_writer/mod.rs
@@ -9,12 +9,14 @@ use vector_lib::event::Event;
 // Module declarations
 pub mod converter;
 pub mod delta_ops;
+pub mod errors;
 pub mod schema;
 pub mod types;
 
 // Re-export main types
 pub use converter::EventConverter;
 pub use delta_ops::DeltaOpsManager;
+pub use errors::is_stale_delta_log_error;
 pub use schema::SchemaManager;
 pub use types::TypeConverter;
 

--- a/src/sinks/deltalake/processor.rs
+++ b/src/sinks/deltalake/processor.rs
@@ -1,13 +1,16 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::{stream::BoxStream, StreamExt};
 use tokio::sync::Mutex;
 use vector_lib::event::Event;
 use vector_lib::sink::StreamSink;
 
-use crate::common::deltalake_writer::{DeltaLakeWriter, DeltaTableConfig, WriteConfig};
+use crate::common::deltalake_writer::{
+    is_stale_delta_log_error, DeltaLakeWriter, DeltaTableConfig, WriteConfig,
+};
 
 /// Delta Lake sink processor
 pub struct DeltaLakeSink {
@@ -69,30 +72,41 @@ impl DeltaLakeSink {
         // Write each table's events
         for (table_name, table_events) in table_events {
             if let Err(e) = self.write_table_events(&table_name, table_events).await {
-                let error_msg = e.to_string();
-                if error_msg.contains("log segment")
-                    || error_msg.contains("Invalid table version")
-                    || error_msg.contains("not found")
-                    || error_msg.contains("No such file or directory")
-                {
-                    panic!(
-                        "Delta Lake corruption detected for table {}: {}",
-                        table_name, error_msg
-                    );
-                } else {
-                    error!("Failed to write events to table {}: {}", table_name, e);
-                }
+                error!("Failed to write events to table {}: {}", table_name, e);
             }
         }
 
         Ok(())
     }
 
-    /// Write events to a specific table
+    /// Write events to a specific table, evicting and reopening the writer once on stale log errors.
     async fn write_table_events(
         &self,
         table_name: &str,
         events: Vec<Event>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match self
+            .write_table_events_once(table_name, &events)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(e) if is_stale_delta_log_error(&e.to_string()) => {
+                warn!(
+                    "Stale Delta log for table {}, evicting cached writer and retrying once: {}",
+                    table_name, e
+                );
+                self.writers.lock().await.remove(table_name);
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                self.write_table_events_once(table_name, &events).await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn write_table_events_once(
+        &self,
+        table_name: &str,
+        events: &[Event],
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Get or create writer for this table
         let mut writers = self.writers.lock().await;
@@ -135,7 +149,7 @@ impl DeltaLakeSink {
         });
 
         // Write events
-        writer.write_events(events).await?;
+        writer.write_events(events.to_vec()).await?;
 
         Ok(())
     }
@@ -165,9 +179,36 @@ impl StreamSink<Event> for DeltaLakeSink {
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
-    use vector_lib::event::LogEvent;
+    use std::fs;
+    use vector_lib::event::{LogEvent, ObjectMap};
 
-    fn create_test_event(table_field: &str, table_name: &str) -> Event {
+    fn create_test_event(table_name: &str, index: i64) -> Event {
+        let mut log = LogEvent::from(BTreeMap::new());
+        log.insert("_vector_table", table_name);
+        log.insert("_vector_source_table", "TEST_SOURCE");
+        log.insert("_vector_source_schema", "test_schema");
+        log.insert("_vector_instance", "test-instance");
+        log.insert("_vector_timestamp", "2024-06-01T00:00:00Z");
+        log.insert("id", index);
+        log.insert("value", format!("row-{index}"));
+
+        let mut schema_meta = ObjectMap::new();
+        schema_meta.insert("_partition_by".into(), vector_lib::event::Value::from("date"));
+        let mut id_meta = ObjectMap::new();
+        id_meta.insert("mysql_type".into(), vector_lib::event::Value::from("bigint"));
+        schema_meta.insert("id".into(), vector_lib::event::Value::Object(id_meta));
+        let mut value_meta = ObjectMap::new();
+        value_meta.insert(
+            "mysql_type".into(),
+            vector_lib::event::Value::from("varchar(64)"),
+        );
+        schema_meta.insert("value".into(), vector_lib::event::Value::Object(value_meta));
+        log.insert("_schema_metadata", vector_lib::event::Value::Object(schema_meta));
+
+        Event::Log(log)
+    }
+
+    fn create_test_event_legacy(table_field: &str, table_name: &str) -> Event {
         let mut log = LogEvent::from(BTreeMap::new());
         log.insert(table_field, table_name);
         log.insert("test_field", "test_value");
@@ -176,7 +217,7 @@ mod tests {
 
     #[test]
     fn test_table_name_extraction_from_vector_table() {
-        let event = create_test_event("_vector_table", "test_table");
+        let event = create_test_event_legacy("_vector_table", "test_table");
         if let Event::Log(log) = &event {
             let table_name = log
                 .get("_vector_table")
@@ -189,7 +230,7 @@ mod tests {
 
     #[test]
     fn test_table_name_extraction_from_dest_table() {
-        let event = create_test_event("dest_table", "my_dest_table");
+        let event = create_test_event_legacy("dest_table", "my_dest_table");
         if let Event::Log(log) = &event {
             let table_name = log
                 .get("_vector_table")
@@ -202,7 +243,7 @@ mod tests {
 
     #[test]
     fn test_table_name_extraction_from_table() {
-        let event = create_test_event("table", "fallback_table");
+        let event = create_test_event_legacy("table", "fallback_table");
         if let Event::Log(log) = &event {
             let table_name = log
                 .get("_vector_table")
@@ -235,9 +276,9 @@ mod tests {
     #[test]
     fn test_events_grouping_by_table() {
         let events = vec![
-            create_test_event("_vector_table", "table_a"),
-            create_test_event("_vector_table", "table_b"),
-            create_test_event("_vector_table", "table_a"),
+            create_test_event_legacy("_vector_table", "table_a"),
+            create_test_event_legacy("_vector_table", "table_b"),
+            create_test_event_legacy("_vector_table", "table_a"),
         ];
 
         let mut table_events: HashMap<String, Vec<Event>> = HashMap::new();
@@ -261,5 +302,65 @@ mod tests {
         assert_eq!(table_events.len(), 2);
         assert_eq!(table_events.get("table_a").unwrap().len(), 2);
         assert_eq!(table_events.get("table_b").unwrap().len(), 1);
+    }
+
+    fn delta_log_json_files(delta_log_path: &std::path::Path) -> Vec<PathBuf> {
+        let mut files: Vec<PathBuf> = fs::read_dir(delta_log_path)
+            .expect("read _delta_log")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+            .collect();
+        files.sort();
+        files
+    }
+
+    #[tokio::test]
+    async fn sink_process_events_recovers_after_simulated_compaction() {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let base_path = std::env::temp_dir().join(format!("deltalake_sink_stale_log_{nanos}"));
+        let table_name = "recover_table";
+        let table_path = base_path.join(table_name);
+        fs::create_dir_all(&table_path).expect("create table dir");
+
+        let sink = DeltaLakeSink::new(
+            base_path.clone(),
+            vec![DeltaTableConfig {
+                name: table_name.to_string(),
+                schema_evolution: Some(true),
+            }],
+            WriteConfig {
+                batch_size: 1000,
+                timeout_secs: 30,
+            },
+            None,
+        );
+
+        for batch in 0..5 {
+            let events: Vec<Event> = (0..3)
+                .map(|i| create_test_event(table_name, i))
+                .collect();
+            sink.process_events(events)
+                .await
+                .expect("seed batch should write");
+            let _ = batch;
+        }
+
+        let delta_log_path = table_path.join("_delta_log");
+        let json_files = delta_log_json_files(&delta_log_path);
+        assert!(json_files.len() >= 3);
+        let latest = json_files.last().expect("latest delta log json").clone();
+        fs::remove_file(latest).expect("simulate compaction");
+
+        // Must not panic; stale-log recovery should allow the batch to be written.
+        sink.process_events(vec![create_test_event(table_name, 999)])
+            .await
+            .expect("sink should recover after simulated compaction");
+
+        assert!(delta_log_json_files(&delta_log_path).len() >= 1);
+        let _ = fs::remove_dir_all(&base_path);
     }
 }

--- a/src/sinks/topsql_data_deltalake/processor.rs
+++ b/src/sinks/topsql_data_deltalake/processor.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::{stream::BoxStream, StreamExt};
 use tokio::sync::mpsc;
@@ -8,7 +9,9 @@ use tokio::sync::Mutex;
 use vector_lib::event::{Event, LogEvent};
 use vector_lib::sink::StreamSink;
 
-use crate::common::deltalake_writer::{DeltaLakeWriter, DeltaTableConfig, WriteConfig};
+use crate::common::deltalake_writer::{
+    is_stale_delta_log_error, DeltaLakeWriter, DeltaTableConfig, WriteConfig,
+};
 use crate::common::keyspace_cluster::{
     path_contains_keyspace_route_segments, replace_keyspace_route_segments,
     route_resolution_retry_delay, KeyspaceRoute, PdKeyspaceResolver,
@@ -401,24 +404,12 @@ impl TopSQLDeltaLakeSink {
         for (writer_key, mut events) in table_events {
             self.add_schema_info(&mut events, &writer_key.table_name);
             if let Err(e) = self.write_table_events(&writer_key, events).await {
-                let error_msg = e.to_string();
-                if error_msg.contains("log segment")
-                    || error_msg.contains("Invalid table version")
-                    || error_msg.contains("not found")
-                    || error_msg.contains("No such file or directory")
-                {
-                    panic!(
-                        "Delta Lake corruption detected for table {}: {}",
-                        writer_key.table_name, error_msg
-                    );
-                } else {
-                    error!(
-                        "Failed to write events to table {} at {}: {}",
-                        writer_key.table_name,
-                        writer_key.table_path.display(),
-                        e
-                    );
-                }
+                error!(
+                    "Failed to write events to table {} at {}: {}",
+                    writer_key.table_name,
+                    writer_key.table_path.display(),
+                    e
+                );
             }
         }
 
@@ -567,11 +558,33 @@ impl TopSQLDeltaLakeSink {
         }
     }
 
-    /// Write events to a specific table
+    /// Write events to a specific table, evicting and reopening the writer once on stale log errors.
     async fn write_table_events(
         &self,
         writer_key: &WriterKey,
         events: Vec<Event>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match self.write_table_events_once(writer_key, &events).await {
+            Ok(()) => Ok(()),
+            Err(e) if is_stale_delta_log_error(&e.to_string()) => {
+                warn!(
+                    "Stale Delta log for table {} at {}, evicting cached writer and retrying once: {}",
+                    writer_key.table_name,
+                    writer_key.table_path.display(),
+                    e
+                );
+                self.writers.lock().await.remove(writer_key);
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                self.write_table_events_once(writer_key, &events).await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn write_table_events_once(
+        &self,
+        writer_key: &WriterKey,
+        events: &[Event],
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let mut writers = self.writers.lock().await;
         let writer = writers.entry(writer_key.clone()).or_insert_with(|| {
@@ -594,7 +607,7 @@ impl TopSQLDeltaLakeSink {
         });
 
         // Write events
-        writer.write_events(events).await?;
+        writer.write_events(events.to_vec()).await?;
 
         Ok(())
     }

--- a/src/sinks/topsql_meta_deltalake/processor.rs
+++ b/src/sinks/topsql_meta_deltalake/processor.rs
@@ -10,7 +10,9 @@ use tokio::sync::Mutex;
 use vector_lib::event::{Event, LogEvent};
 use vector_lib::sink::StreamSink;
 
-use crate::common::deltalake_writer::{DeltaLakeWriter, DeltaTableConfig, WriteConfig};
+use crate::common::deltalake_writer::{
+    is_stale_delta_log_error, DeltaLakeWriter, DeltaTableConfig, WriteConfig,
+};
 use crate::common::keyspace_cluster::{
     path_contains_keyspace_route_segments, replace_keyspace_route_segments,
     route_resolution_retry_delay, KeyspaceRoute, PdKeyspaceResolver,
@@ -380,24 +382,12 @@ impl TopSQLDeltaLakeSink {
         for (writer_key, mut events) in table_events {
             self.add_schema_info(&writer_key.table_name, &mut events);
             if let Err(e) = self.write_table_events(&writer_key, events).await {
-                let error_msg = e.to_string();
-                if error_msg.contains("log segment")
-                    || error_msg.contains("Invalid table version")
-                    || error_msg.contains("not found")
-                    || error_msg.contains("No such file or directory")
-                {
-                    panic!(
-                        "Delta Lake corruption detected for table {}: {}",
-                        writer_key.table_name, error_msg
-                    );
-                } else {
-                    error!(
-                        "Failed to write events to table {} at {}: {}",
-                        writer_key.table_name,
-                        writer_key.table_path.display(),
-                        e
-                    );
-                }
+                error!(
+                    "Failed to write events to table {} at {}: {}",
+                    writer_key.table_name,
+                    writer_key.table_path.display(),
+                    e
+                );
             } else if let Some(keys) = table_dedup_keys.remove(&writer_key) {
                 committed_dedup_keys.extend(keys);
             }
@@ -600,11 +590,33 @@ impl TopSQLDeltaLakeSink {
         );
     }
 
-    /// Write events to a specific table
+    /// Write events to a specific table, evicting and reopening the writer once on stale log errors.
     async fn write_table_events(
         &self,
         writer_key: &WriterKey,
         events: Vec<Event>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match self.write_table_events_once(writer_key, &events).await {
+            Ok(()) => Ok(()),
+            Err(e) if is_stale_delta_log_error(&e.to_string()) => {
+                warn!(
+                    "Stale Delta log for table {} at {}, evicting cached writer and retrying once: {}",
+                    writer_key.table_name,
+                    writer_key.table_path.display(),
+                    e
+                );
+                self.writers.lock().await.remove(writer_key);
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                self.write_table_events_once(writer_key, &events).await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn write_table_events_once(
+        &self,
+        writer_key: &WriterKey,
+        events: &[Event],
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Get or create writer for this table
         let mut writers = self.writers.lock().await;
@@ -628,7 +640,7 @@ impl TopSQLDeltaLakeSink {
         });
 
         // Write events
-        writer.write_events(events).await?;
+        writer.write_events(events.to_vec()).await?;
 
         Ok(())
     }

--- a/tests/deltalake_stale_log_test.rs
+++ b/tests/deltalake_stale_log_test.rs
@@ -1,0 +1,147 @@
+//! Local Delta Lake test: simulate external compaction removing old _delta_log JSON
+//! files and verify writes recover instead of failing permanently.
+
+#![allow(clippy::print_stdout)]
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use vector_lib::event::{Event, LogEvent, ObjectMap};
+
+use vector_extensions::sinks::deltalake::{DeltaLakeWriter, DeltaTableConfig, WriteConfig};
+
+fn make_event(table_name: &str, index: i64) -> Event {
+    let mut log = LogEvent::from(BTreeMap::new());
+    log.insert("_vector_table", table_name);
+    log.insert("_vector_source_table", "TEST_SOURCE");
+    log.insert("_vector_source_schema", "test_schema");
+    log.insert("_vector_instance", "test-instance");
+    log.insert("_vector_timestamp", "2024-06-01T00:00:00Z");
+    log.insert("id", index);
+    log.insert("value", format!("row-{index}"));
+
+    let mut schema_meta = ObjectMap::new();
+    schema_meta.insert("_partition_by".into(), vector_lib::event::Value::from("date"));
+    let mut id_meta = ObjectMap::new();
+    id_meta.insert("mysql_type".into(), vector_lib::event::Value::from("bigint"));
+    schema_meta.insert("id".into(), vector_lib::event::Value::Object(id_meta));
+    let mut value_meta = ObjectMap::new();
+    value_meta.insert(
+        "mysql_type".into(),
+        vector_lib::event::Value::from("varchar(64)"),
+    );
+    schema_meta.insert("value".into(), vector_lib::event::Value::Object(value_meta));
+    log.insert("_schema_metadata", vector_lib::event::Value::Object(schema_meta));
+
+    Event::Log(log)
+}
+
+fn delta_log_json_files(delta_log_path: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = fs::read_dir(delta_log_path)
+        .expect("read _delta_log")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    files.sort();
+    files
+}
+
+/// Remove the latest commit log JSON file while keeping the contiguous history intact.
+/// This mimics a concurrent compact/remove race where a reader still chases a log
+/// segment that was already deleted, while the table remains valid at an earlier version.
+fn simulate_external_compaction(delta_log_path: &Path) {
+    let json_files = delta_log_json_files(delta_log_path);
+    assert!(
+        json_files.len() >= 3,
+        "need at least 3 json log files before compaction simulation"
+    );
+
+    let stale_file = json_files.last().expect("latest delta log json");
+    println!("Simulating compaction: removing {:?}", stale_file);
+    fs::remove_file(stale_file).expect("remove stale delta log json");
+}
+
+fn unique_table_dir(name: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("{name}_{nanos}"))
+}
+
+async fn write_batch(writer: &mut DeltaLakeWriter, table_name: &str, start: i64, count: i64) {
+    let events: Vec<Event> = (start..start + count)
+        .map(|i| make_event(table_name, i))
+        .collect();
+    writer
+        .write_events(events)
+        .await
+        .expect("seed write should succeed");
+}
+
+#[tokio::test]
+async fn recover_write_after_simulated_delta_log_compaction() {
+    let table_path = unique_table_dir("deltalake_stale_log_recovery");
+    fs::create_dir_all(&table_path).expect("create table dir");
+
+    let table_name = "metrics_table";
+    let write_config = WriteConfig {
+        batch_size: 1000,
+        timeout_secs: 30,
+    };
+    let table_config = DeltaTableConfig {
+        name: table_name.to_string(),
+        schema_evolution: Some(true),
+    };
+
+    let mut writer = DeltaLakeWriter::new(
+        table_path.clone(),
+        table_config.clone(),
+        write_config.clone(),
+        None,
+    );
+
+    // Build a multi-version table so _delta_log has several JSON commits.
+    for batch in 0..5 {
+        write_batch(&mut writer, table_name, batch * 10, 3).await;
+    }
+
+    let delta_log_path = table_path.join("_delta_log");
+    let json_before = delta_log_json_files(&delta_log_path);
+    println!("Delta log json files before compaction simulation: {}", json_before.len());
+    assert!(json_before.len() >= 3, "expected multiple delta log commits");
+
+    simulate_external_compaction(&delta_log_path);
+
+    let recovery_events = vec![make_event(table_name, 999)];
+    match writer.write_events(recovery_events.clone()).await {
+        Ok(()) => {}
+        Err(error) if vector_extensions::common::deltalake_writer::is_stale_delta_log_error(&error.to_string()) => {
+            writer = DeltaLakeWriter::new(
+                table_path.clone(),
+                DeltaTableConfig {
+                    name: table_name.to_string(),
+                    schema_evolution: Some(true),
+                },
+                write_config.clone(),
+                None,
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            writer
+                .write_events(recovery_events)
+                .await
+                .expect("write should recover after reopening table writer");
+        }
+        Err(error) => panic!("unexpected write failure: {error}"),
+    }
+
+    let json_after = delta_log_json_files(&delta_log_path);
+    assert!(
+        !json_after.is_empty(),
+        "table should remain writable after recovery"
+    );
+
+    let _ = fs::remove_dir_all(&table_path);
+}


### PR DESCRIPTION
## Summary

Add Google Cloud Storage (GCS) support for Delta Lake sinks, harden write recovery when Delta log views go stale (e.g. after external compaction), and shrink Docker image size for release builds.

## Changes

### Delta Lake / GCS
- Enable the `gcs` feature on the `deltalake` crate so tables can be written to GCS in addition to S3 and Azure.
- Centralize stale Delta log detection in `is_stale_delta_log_error` (shared by the writer and sinks).
- On stale log / missing `_delta_log` segment errors:
  - Retry inside `DeltaOpsManager` after reloading the table.
  - Evict the cached writer and retry once in `deltalake`, `topsql_data_deltalake`, and `topsql_meta_deltalake` sinks (with a short backoff).
- Stop panicking on these corruption-like errors; log and recover so the pipeline can continue.

### Docker / release size
- Release profile: `strip = true`, `panic = "abort"`, `opt-level = "z"`.
- Slim the Debian Dockerfile (multi-stage, drop unused runtime packages).
- Support alternate bases via `DOCKER_BASE` (`alpine` / `minimal`) and add Makefile targets:
  - `release-docker-alpine`
  - `release-docker-minimal`
  - `release-docker-nextgen-alpine`

### Tests
- Add `tests/deltalake_stale_log_test.rs` to simulate external compaction removing a `_delta_log` JSON file and verify write recovery after reopening the writer.

## Commits (vs `0.49`)

- `393f2b5` deltalake gcs
- `6636544` / `10bc14c` optimize docker image size
- `6865bfc` fix delta lake write issue
- (plus merge commits from `0.49`)

## Test plan

- [ ] Build release binary and confirm GCS Delta Lake writes succeed with valid GCS credentials / storage options
- [ ] Run unit tests for `is_stale_delta_log_error`
- [ ] Run `tests/deltalake_stale_log_test.rs` and confirm recovery after simulated log compaction
- [ ] Smoke-test `deltalake` / `topsql_data_deltalake` / `topsql_meta_deltalake` sinks against S3 and GCS
- [ ] Verify Debian Docker image still builds; optionally verify Alpine/minimal targets if those Dockerfiles are shipped with this PR
- [ ] Confirm image size reduction vs previous `0.49` Debian image